### PR TITLE
Update setup for SureSupport hosting (Unix socket PostgreSQL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
 DEBUG=True
 SECRET_KEY=your-secret-key-here-change-in-production
+# For Unix socket (SureSupport / shared hosting — no TCP):
+#   DATABASE_URL=postgresql://bookforbook:PASSWORD@/bookforbook?host=/home/USERNAME/private/postgres1/run
+# For TCP (local dev / managed hosting):
+#   DATABASE_URL=postgresql://bookforbook:bookforbook@localhost:5432/bookforbook
 DATABASE_URL=postgresql://bookforbook:bookforbook@localhost:5432/bookforbook
 REDIS_URL=redis://localhost:6379/0
 ALLOWED_HOSTS=localhost,127.0.0.1

--- a/README.md
+++ b/README.md
@@ -31,36 +31,100 @@ Verified libraries and bookstores can receive book donations.
 
 - Python 3.12+
 - Node.js 20+
-- PostgreSQL 16
 - Redis
+- PostgreSQL 16 — set up via `setup_postgres.sh` (see below)
 
-### Backend
+### 1. Set up PostgreSQL
+
+Run the setup script once to create a managed PostgreSQL instance:
 
 ```bash
-# Start PostgreSQL and Redis (if not already running)
-# e.g. on Ubuntu/Debian:  sudo service postgresql start && sudo service redis-server start
-# e.g. on macOS:          brew services start postgresql@16 && brew services start redis
+sh setup_postgres.sh
+```
 
-# Create the database
-createdb bookforbook
+This creates a PostgreSQL instance at `~/private/postgres1/` running on a Unix socket
+(no TCP port — this is normal for this hosting environment).
 
-cp .env.example .env          # fill in secrets
+Load the environment variables it configures:
+
+```bash
+source ~/apps/postgres1/home/.bashrc
+```
+
+> Add that `source` line to your shell's `~/.bashrc` (or `~/.profile`) so `PGHOST` is set
+> automatically on every login.
+
+Verify the instance is running and you can connect:
+
+```bash
+psql postgres -c "\conninfo"
+```
+
+Create the application database and user:
+
+```bash
+# Generate a strong password
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+
+# Create the user (replace YOUR_PASSWORD with the generated password)
+psql postgres -c "CREATE USER bookforbook WITH PASSWORD 'YOUR_PASSWORD';"
+
+# Create the database owned by that user
+psql postgres -c "CREATE DATABASE bookforbook OWNER bookforbook;"
+
+# Grant schema permissions
+psql bookforbook -c "GRANT ALL ON SCHEMA public TO bookforbook;"
+```
+
+Note your socket directory — you'll need it for `.env`:
+
+```bash
+echo $PGHOST
+# e.g. /home/yourusername/private/postgres1/run
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+
+```
+SECRET_KEY=<generate with: python3 -c "import secrets; print(secrets.token_urlsafe(50))">
+DATABASE_URL=postgresql://bookforbook:YOUR_PASSWORD@/bookforbook?host=/home/YOUR_USERNAME/private/postgres1/run
+REDIS_URL=redis://localhost:6379/0
+FIELD_ENCRYPTION_KEY=<generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())">
+ALLOWED_HOSTS=yourdomain.com
+FRONTEND_URL=https://yourdomain.com
+```
+
+Replace `/home/YOUR_USERNAME/private/postgres1/run` with the actual path from `echo $PGHOST`.
+
+### 3. Install dependencies and run migrations
+
+```bash
 python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 python manage.py migrate
 python manage.py createsuperuser
-python manage.py runserver
 ```
 
+### 4. Start the application
+
 ```bash
-# Celery worker (separate terminal)
+# Django dev server
+python manage.py runserver
+
+# Celery worker (separate terminal, with .venv activated)
 celery -A config worker -l info
 
-# Celery beat scheduler (separate terminal)
+# Celery beat scheduler (separate terminal, with .venv activated)
 celery -A config beat -l info
 ```
 
-### Frontend
+### 5. Frontend
 
 ```bash
 cd frontend

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -13,21 +13,27 @@ DATABASE_URL = config('DATABASE_URL', default='')
 
 
 def _parse_db_url(url: str) -> dict:
-    """Simple DATABASE_URL parser that supports postgresql:// and postgres:// schemes."""
+    """Simple DATABASE_URL parser that supports postgresql:// and postgres:// schemes.
+
+    Supports TCP:   postgresql://user:pass@host:5432/dbname
+    Supports socket: postgresql://user:pass@/dbname?host=/path/to/socket/dir
+    """
     pattern = re.compile(
         r'(?P<scheme>postgres(?:ql)?)://(?P<user>[^:]+):(?P<password>[^@]*)@'
-        r'(?P<host>[^:/]+)(?::(?P<port>\d+))?/(?P<name>[^?]+)'
+        r'(?P<host>[^:/]*)(?::(?P<port>\d+))?/(?P<name>[^?]+)'
+        r'(?:\?host=(?P<socketdir>[^&\s]+))?'
     )
     match = pattern.match(url)
     if not match:
         return {}
+    host = match.group('socketdir') or match.group('host') or ''
     return {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': match.group('name'),
         'USER': match.group('user'),
         'PASSWORD': match.group('password'),
-        'HOST': match.group('host'),
-        'PORT': match.group('port') or '5432',
+        'HOST': host,
+        'PORT': match.group('port') or '',
     }
 
 

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -19,23 +19,32 @@ X_FRAME_OPTIONS = 'DENY'
 
 
 def _parse_db_url(url: str) -> dict:
-    """Parse a DATABASE_URL string into Django DATABASES config."""
+    """Parse a DATABASE_URL string into Django DATABASES config.
+
+    Supports TCP:    postgresql://user:pass@host:5432/dbname
+    Supports socket: postgresql://user:pass@/dbname?host=/path/to/socket/dir
+    """
     pattern = re.compile(
         r'(?P<scheme>postgres(?:ql)?)://(?P<user>[^:]+):(?P<password>[^@]*)@'
-        r'(?P<host>[^:/]+)(?::(?P<port>\d+))?/(?P<name>[^?]+)'
+        r'(?P<host>[^:/]*)(?::(?P<port>\d+))?/(?P<name>[^?]+)'
+        r'(?:\?host=(?P<socketdir>[^&\s]+))?'
     )
     match = pattern.match(url)
     if not match:
         raise ValueError(f'Invalid DATABASE_URL: {url!r}')
+    socket_dir = match.group('socketdir')
+    host = socket_dir or match.group('host') or ''
+    options: dict = {'CONN_MAX_AGE': 600}
+    if not socket_dir:
+        options['OPTIONS'] = {'sslmode': 'require'}
     return {
         'ENGINE': 'django.db.backends.postgresql',
         'NAME': match.group('name'),
         'USER': match.group('user'),
         'PASSWORD': match.group('password'),
-        'HOST': match.group('host'),
-        'PORT': match.group('port') or '5432',
-        'OPTIONS': {'sslmode': 'require'},
-        'CONN_MAX_AGE': 600,
+        'HOST': host,
+        'PORT': match.group('port') or '',
+        **options,
     }
 
 


### PR DESCRIPTION
- Rewrite README setup section to use setup_postgres.sh for PostgreSQL
- Update DATABASE_URL parsers in dev and production settings to support socket-path format: postgresql://user:pass@/db?host=/path/to/socket
- Production parser skips sslmode=require for socket connections
- Update .env.example with socket and TCP format examples

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq