### PR TITLE
Replace Celery + Redis with Django-Q2 (PostgreSQL broker)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,6 @@ SECRET_KEY=your-secret-key-here-change-in-production
 # For TCP (local dev / managed hosting):
 #   DATABASE_URL=postgresql://bookforbook:bookforbook@localhost:5432/bookforbook
 DATABASE_URL=postgresql://bookforbook:bookforbook@localhost:5432/bookforbook
-REDIS_URL=redis://localhost:6379/0
 ALLOWED_HOSTS=localhost,127.0.0.1
 CORS_ALLOWED_ORIGINS=http://localhost:5173,http://localhost:3000
 FIELD_ENCRYPTION_KEY=your-fernet-key-here

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,14 +14,14 @@ BookForBook is a book bartering platform where users in the continental USA trad
 |-------|-----------|
 | Backend | Django 5.x + Django REST Framework |
 | Database | PostgreSQL 16 |
-| Task queue | Celery + Redis |
+| Task queue | Django-Q2 (PostgreSQL broker) |
 | Frontend | React 18 (Vite) as PWA |
 | ISBN enrichment | Open Library API (free, no key required) |
 | Notifications | Email via SendGrid/AWS SES; optional SMS via Twilio |
 | Search | PostgreSQL full-text search (upgrade to Meilisearch later if needed) |
 | File storage | S3-compatible (AWS S3, Backblaze B2, or local dev) |
 | Auth | JWT via `djangorestframework-simplejwt` |
-| Deployment | Native (PostgreSQL + Redis installed directly), or managed (Railway/Render) |
+| Deployment | Native (PostgreSQL installed directly), or managed (Railway/Render) |
 
 ---
 
@@ -43,7 +43,6 @@ bookforbook/
 │   │   ├── development.py
 │   │   └── production.py
 │   ├── urls.py
-│   ├── celery.py
 │   └── wsgi.py
 │
 ├── apps/
@@ -54,7 +53,7 @@ bookforbook/
 │   ├── trading/                     # Proposals, Trades, Shipments
 │   ├── donations/                   # Institutional donation workflow
 │   ├── ratings/                     # Rating system + rolling average
-│   ├── notifications/               # Email/in-app notifications, Celery tasks
+│   ├── notifications/               # Email/in-app notifications, Django-Q2 tasks
 │   └── messaging/                   # Structured trade messages
 │
 ├── frontend/                        # React PWA (Vite + vite-plugin-pwa)
@@ -116,7 +115,7 @@ All primary keys are UUIDs. All personal address fields are encrypted at rest.
 ### Trade (execution record, created after confirmation)
 - `source_type`: `match` | `proposal` | `donation`
 - `auto_close_at = confirmed_at + 3 weeks`
-- Weekly Celery task sends up to 3 rating reminders; auto-closes with `auto_closed` status if no rating submitted
+- Weekly background task sends up to 3 rating reminders; auto-closes with `auto_closed` status if no rating submitted
 
 ### TradeShipment (one per direction)
 - `status`: `pending` | `shipped` | `received` | `not_received`
@@ -179,7 +178,7 @@ browse/         available/, available/?q=, partner/:id/books/, shipping-estimate
 
 ## Core Workflows
 
-### Matching Engine (Celery, triggered on new UserBook/WishlistItem + periodic 6h scan)
+### Matching Engine (Django-Q2, triggered on new UserBook/WishlistItem + periodic 6h scan)
 
 **Direct match:**
 ```
@@ -246,7 +245,7 @@ No API key required. Rate-limit requests to avoid abuse. Cache all results local
 - **UUID primary keys** on all models
 - **ENUM fields**: use Django's `TextChoices` for status/type fields
 - **Encrypted fields**: use `django-fernet-fields` or equivalent for address fields
-- **Celery tasks**: defined in `tasks.py` per app; triggered via Django signals
+- **Background tasks**: defined in `tasks.py` per app; dispatched via `django_q.tasks.async_task()`; triggered via Django signals
 - **Type hints**: use throughout Python code
 - **Serializers validate**: all input at the API boundary; never trust raw request data
 
@@ -265,9 +264,9 @@ No API key required. Rate-limit requests to avoid abuse. Cache all results local
 ## Development Setup (When Code Exists)
 
 ```bash
-# Start PostgreSQL and Redis (must be installed and running natively)
-# Ubuntu/Debian: sudo service postgresql start && sudo service redis-server start
-# macOS:        brew services start postgresql@16 && brew services start redis
+# Start PostgreSQL (must be installed and running natively)
+# Ubuntu/Debian: sudo service postgresql start
+# macOS:        brew services start postgresql@16
 
 # Create the database
 createdb bookforbook
@@ -280,8 +279,8 @@ python manage.py migrate
 python manage.py createsuperuser
 python manage.py runserver
 
-# Celery worker (separate terminal)
-celery -A config worker -l info
+# Task worker + scheduler (separate terminal)
+python manage.py qcluster
 
 # Frontend
 cd frontend
@@ -316,9 +315,8 @@ See `docs/bookswap-architecture.md` for full details.
 |------|---------|
 | `docs/bookswap-architecture.md` | Complete architecture specification — read before implementing anything |
 | `config/settings/base.py` | Django base settings (to be created) |
-| `config/celery.py` | Celery app configuration (to be created) |
 | `apps/matching/services/direct_matcher.py` | Direct match detection logic (to be created) |
 | `apps/matching/services/ring_detector.py` | Exchange ring cycle detection (to be created) |
 | `apps/books/services/openlibrary.py` | Open Library API client (to be created) |
 | `apps/ratings/services/rolling_average.py` | Rolling average recomputation (to be created) |
-| `apps/notifications/tasks.py` | All Celery notification tasks (to be created) |
+| `apps/notifications/tasks.py` | All notification tasks (to be created) |

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Verified libraries and bookstores can receive book donations.
 |---|---|
 | Backend | Django 5.x + Django REST Framework |
 | Database | PostgreSQL 16 |
-| Task queue | Celery + Redis |
+| Task queue | Django-Q2 (PostgreSQL broker) |
 | Frontend | React 18 (Vite) as PWA |
 | ISBN data | Open Library API |
 | Auth | JWT (djangorestframework-simplejwt) |
@@ -31,7 +31,6 @@ Verified libraries and bookstores can receive book donations.
 
 - Python 3.12+
 - Node.js 20+
-- Redis
 - PostgreSQL 16 — set up via `setup_postgres.sh` (see below)
 
 ### 1. Set up PostgreSQL
@@ -94,7 +93,6 @@ Edit `.env` and set at minimum:
 ```
 SECRET_KEY=<generate with: python3 -c "import secrets; print(secrets.token_urlsafe(50))">
 DATABASE_URL=postgresql://bookforbook:YOUR_PASSWORD@/bookforbook?host=/home/YOUR_USERNAME/private/postgres1/run
-REDIS_URL=redis://localhost:6379/0
 FIELD_ENCRYPTION_KEY=<generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())">
 ALLOWED_HOSTS=yourdomain.com
 FRONTEND_URL=https://yourdomain.com
@@ -117,11 +115,8 @@ python manage.py createsuperuser
 # Django dev server
 python manage.py runserver
 
-# Celery worker (separate terminal, with .venv activated)
-celery -A config worker -l info
-
-# Celery beat scheduler (separate terminal, with .venv activated)
-celery -A config beat -l info
+# Task worker + scheduler (separate terminal, with .venv activated)
+python manage.py qcluster
 ```
 
 ### 5. Frontend
@@ -160,7 +155,7 @@ All endpoints live under `/api/v1/`. JWT auth is required except for browse/sear
 
 ```
 bookforbook/
-├── config/                  # Django project settings, Celery, URLs
+├── config/                  # Django project settings, URLs
 ├── apps/
 │   ├── accounts/            # User model, auth, profiles
 │   ├── books/               # Book cache, ISBN lookup, Open Library client
@@ -169,7 +164,7 @@ bookforbook/
 │   ├── trading/             # Proposals, trades, shipment tracking
 │   ├── donations/           # Institutional donation workflow
 │   ├── ratings/             # 1-5 star ratings with rolling average
-│   ├── notifications/       # Email/in-app notifications via Celery
+│   ├── notifications/       # Email/in-app notifications via Django-Q2
 │   └── messaging/           # Structured trade messages
 ├── frontend/                # React PWA (Vite)
 ├── scripts/                 # Dev utilities (seed data)

--- a/apps/accounts/signals.py
+++ b/apps/accounts/signals.py
@@ -32,8 +32,8 @@ def on_user_login(sender, request, user, **kwargs):
             )
             # Trigger matching scan for newly available books
             try:
-                from apps.matching.tasks import run_matching_for_relisted_books
-                run_matching_for_relisted_books.delay(str(user.pk))
+                from django_q.tasks import async_task
+                async_task('apps.matching.tasks.run_matching_for_relisted_books', str(user.pk))
             except Exception:
                 logger.exception('Failed to queue matching for relisted books, user %s', user.pk)
 

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -38,10 +38,10 @@ class RegisterView(APIView):
 
         # Send verification email asynchronously
         try:
-            from apps.notifications.tasks import send_verification_email
+            from django_q.tasks import async_task
             uid = urlsafe_base64_encode(force_bytes(user.pk))
             token = email_verification_token.make_token(user)
-            send_verification_email.delay(str(user.pk), uid, token)
+            async_task('apps.notifications.tasks.send_verification_email', str(user.pk), uid, token)
         except Exception:
             logger.exception('Failed to queue verification email for user %s', user.pk)
 
@@ -97,8 +97,8 @@ class PasswordResetRequestView(APIView):
             user = User.objects.get(email=email, is_active=True)
             uid = urlsafe_base64_encode(force_bytes(user.pk))
             token = default_token_generator.make_token(user)
-            from apps.notifications.tasks import send_password_reset_email
-            send_password_reset_email.delay(str(user.pk), uid, token)
+            from django_q.tasks import async_task
+            async_task('apps.notifications.tasks.send_password_reset_email', str(user.pk), uid, token)
         except User.DoesNotExist:
             pass  # Don't reveal if email exists
 
@@ -144,8 +144,8 @@ class UserMeView(APIView):
 
         # Queue GDPR export + deletion
         try:
-            from apps.notifications.tasks import send_account_deletion_initiated
-            send_account_deletion_initiated.delay(str(user.pk))
+            from django_q.tasks import async_task
+            async_task('apps.notifications.tasks.send_account_deletion_initiated', str(user.pk))
         except Exception:
             logger.exception('Failed to queue deletion notification for user %s', user.pk)
 

--- a/apps/inventory/views.py
+++ b/apps/inventory/views.py
@@ -51,8 +51,8 @@ class MyBooksView(APIView):
 
         # Trigger async matching scan
         try:
-            from apps.matching.tasks import run_matching_for_new_item
-            run_matching_for_new_item.delay(user_book_id=str(user_book.pk))
+            from django_q.tasks import async_task
+            async_task('apps.matching.tasks.run_matching_for_new_item', user_book_id=str(user_book.pk))
         except Exception:
             logger.exception('Failed to queue matching task for user_book %s', user_book.pk)
 
@@ -105,8 +105,8 @@ class WishlistView(APIView):
 
         # Trigger async matching scan
         try:
-            from apps.matching.tasks import run_matching_for_new_item
-            run_matching_for_new_item.delay(wishlist_item_id=str(item.pk))
+            from django_q.tasks import async_task
+            async_task('apps.matching.tasks.run_matching_for_new_item', wishlist_item_id=str(item.pk))
         except Exception:
             logger.exception('Failed to queue matching task for wishlist_item %s', item.pk)
 

--- a/apps/matching/services/direct_matcher.py
+++ b/apps/matching/services/direct_matcher.py
@@ -137,8 +137,8 @@ def run_direct_matching(user_book: Optional[UserBook] = None) -> list[Match]:
 
                 # Notify asynchronously
                 try:
-                    from apps.notifications.tasks import send_match_notification
-                    send_match_notification.delay(str(match.pk))
+                    from django_q.tasks import async_task
+                    async_task('apps.notifications.tasks.send_match_notification', str(match.pk))
                 except Exception:
                     logger.exception('Failed to queue match notification for %s', match.pk)
 

--- a/apps/matching/services/ring_detector.py
+++ b/apps/matching/services/ring_detector.py
@@ -107,8 +107,8 @@ def run_ring_detection() -> list[Match]:
                 created_matches.append(match)
                 logger.info('Created ring match %s with %d participants', match.pk, len(cycle))
                 try:
-                    from apps.notifications.tasks import send_match_notification
-                    send_match_notification.delay(str(match.pk))
+                    from django_q.tasks import async_task
+                    async_task('apps.notifications.tasks.send_match_notification', str(match.pk))
                 except Exception:
                     logger.exception('Failed to queue ring match notification for %s', match.pk)
 

--- a/apps/matching/tasks.py
+++ b/apps/matching/tasks.py
@@ -1,79 +1,66 @@
 import logging
 
-from celery import shared_task
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def run_matching_for_new_item(self, user_book_id=None, wishlist_item_id=None):
+def run_matching_for_new_item(user_book_id=None, wishlist_item_id=None):
     """
     Triggered when a new UserBook or WishlistItem is added.
     Runs direct matching (and optionally ring detection) for the new item.
     """
-    try:
-        from apps.matching.services.direct_matcher import run_direct_matching
+    from apps.matching.services.direct_matcher import run_direct_matching
 
-        if user_book_id:
+    if user_book_id:
+        from apps.inventory.models import UserBook
+        try:
+            user_book = UserBook.objects.select_related('user', 'book').get(pk=user_book_id)
+            matches = run_direct_matching(user_book=user_book)
+            logger.info('Direct matching for UserBook %s found %d match(es)', user_book_id, len(matches))
+        except UserBook.DoesNotExist:
+            logger.warning('UserBook %s not found for matching', user_book_id)
+
+    elif wishlist_item_id:
+        from apps.inventory.models import WishlistItem
+        try:
+            item = WishlistItem.objects.get(pk=wishlist_item_id)
+            # Find books available that this user wants
             from apps.inventory.models import UserBook
-            try:
-                user_book = UserBook.objects.select_related('user', 'book').get(pk=user_book_id)
-                matches = run_direct_matching(user_book=user_book)
-                logger.info('Direct matching for UserBook %s found %d match(es)', user_book_id, len(matches))
-            except UserBook.DoesNotExist:
-                logger.warning('UserBook %s not found for matching', user_book_id)
-
-        elif wishlist_item_id:
-            from apps.inventory.models import WishlistItem
-            try:
-                item = WishlistItem.objects.get(pk=wishlist_item_id)
-                # Find books available that this user wants
-                from apps.inventory.models import UserBook
-                available = UserBook.objects.filter(
-                    book=item.book,
-                    status=UserBook.Status.AVAILABLE,
-                ).select_related('user', 'book')
-                total = 0
-                for ub in available:
-                    matches = run_direct_matching(user_book=ub)
-                    total += len(matches)
-                logger.info('Direct matching for WishlistItem %s found %d match(es)', wishlist_item_id, total)
-            except WishlistItem.DoesNotExist:
-                logger.warning('WishlistItem %s not found for matching', wishlist_item_id)
-
-    except Exception as exc:
-        logger.exception('Error in run_matching_for_new_item')
-        raise self.retry(exc=exc)
+            available = UserBook.objects.filter(
+                book=item.book,
+                status=UserBook.Status.AVAILABLE,
+            ).select_related('user', 'book')
+            total = 0
+            for ub in available:
+                matches = run_direct_matching(user_book=ub)
+                total += len(matches)
+            logger.info('Direct matching for WishlistItem %s found %d match(es)', wishlist_item_id, total)
+        except WishlistItem.DoesNotExist:
+            logger.warning('WishlistItem %s not found for matching', wishlist_item_id)
 
 
-@shared_task(bind=True, max_retries=2, default_retry_delay=300)
-def run_matching_for_relisted_books(self, user_id: str):
+def run_matching_for_relisted_books(user_id: str):
     """
     Triggered when a user logs back in after being delisted.
     Runs matching for all their newly available books.
     """
-    try:
-        from apps.inventory.models import UserBook
-        from apps.matching.services.direct_matcher import run_direct_matching
+    from apps.inventory.models import UserBook
+    from apps.matching.services.direct_matcher import run_direct_matching
 
-        books = UserBook.objects.filter(
-            user_id=user_id,
-            status=UserBook.Status.AVAILABLE,
-        ).select_related('user', 'book')
+    books = UserBook.objects.filter(
+        user_id=user_id,
+        status=UserBook.Status.AVAILABLE,
+    ).select_related('user', 'book')
 
-        total = 0
-        for ub in books:
-            matches = run_direct_matching(user_book=ub)
-            total += len(matches)
+    total = 0
+    for ub in books:
+        matches = run_direct_matching(user_book=ub)
+        total += len(matches)
 
-        logger.info('Relisted-books matching for user %s found %d match(es)', user_id, total)
-    except Exception as exc:
-        logger.exception('Error in run_matching_for_relisted_books')
-        raise self.retry(exc=exc)
+    logger.info('Relisted-books matching for user %s found %d match(es)', user_id, total)
 
 
-@shared_task
 def run_periodic_matching():
     """
     Periodic full scan — runs every 6 hours.
@@ -95,7 +82,6 @@ def run_periodic_matching():
         logger.exception('Error in periodic ring detection')
 
 
-@shared_task
 def expire_old_matches():
     """
     Periodic task — expire pending/proposed matches past their expiry time.

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -131,8 +131,8 @@ class MatchDeclineView(APIView):
                     from apps.matching.services.ring_detector import retry_ring_after_decline
                     new_match = retry_ring_after_decline(match, user)
                     if new_match:
-                        from apps.notifications.tasks import send_match_notification
-                        send_match_notification.delay(str(new_match.pk))
+                        from django_q.tasks import async_task
+                        async_task('apps.notifications.tasks.send_match_notification', str(new_match.pk))
                     else:
                         # Notify all participants that ring could not be reformed
                         _notify_ring_cancelled(match, user)

--- a/apps/notifications/migrations/0001_create_q_schedules.py
+++ b/apps/notifications/migrations/0001_create_q_schedules.py
@@ -1,0 +1,61 @@
+"""
+Data migration: create Django-Q2 periodic schedules for background tasks.
+"""
+from django.db import migrations
+
+
+def create_schedules(apps, schema_editor):
+    Schedule = apps.get_model('django_q', 'Schedule')
+
+    schedules = [
+        {
+            'name': 'Run periodic matching',
+            'func': 'apps.matching.tasks.run_periodic_matching',
+            'schedule_type': 'I',
+            'minutes': 360,
+        },
+        {
+            'name': 'Expire old matches',
+            'func': 'apps.matching.tasks.expire_old_matches',
+            'schedule_type': 'I',
+            'minutes': 60,
+        },
+        {
+            'name': 'Check user inactivity',
+            'func': 'apps.notifications.tasks.check_inactivity',
+            'schedule_type': 'D',
+        },
+        {
+            'name': 'Send rating reminders',
+            'func': 'apps.trading.tasks.send_rating_reminders',
+            'schedule_type': 'W',
+        },
+        {
+            'name': 'Auto-close trades',
+            'func': 'apps.trading.tasks.auto_close_trades',
+            'schedule_type': 'W',
+        },
+    ]
+
+    for sched in schedules:
+        Schedule.objects.get_or_create(name=sched['name'], defaults=sched)
+
+
+def remove_schedules(apps, schema_editor):
+    Schedule = apps.get_model('django_q', 'Schedule')
+    Schedule.objects.filter(name__in=[
+        'Run periodic matching',
+        'Expire old matches',
+        'Check user inactivity',
+        'Send rating reminders',
+        'Auto-close trades',
+    ]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('django_q', '0001_initial'),
+    ]
+    operations = [
+        migrations.RunPython(create_schedules, remove_schedules),
+    ]

--- a/apps/notifications/tasks.py
+++ b/apps/notifications/tasks.py
@@ -1,177 +1,128 @@
 """
-Celery tasks for notifications — email + in-app.
+Tasks for notifications — email + in-app.
 """
 import logging
 
-from celery import shared_task
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def send_verification_email(self, user_id: str, uid: str, token: str):
+def send_verification_email(user_id: str, uid: str, token: str):
     """Send email verification link to a newly registered user."""
-    try:
-        from apps.accounts.models import User
-        user = User.objects.get(pk=user_id)
-        from apps.notifications.email import send_verification_email as _send
-        _send(user, uid, token)
-    except Exception as exc:
-        logger.exception('send_verification_email failed for user %s', user_id)
-        raise self.retry(exc=exc)
+    from apps.accounts.models import User
+    user = User.objects.get(pk=user_id)
+    from apps.notifications.email import send_verification_email as _send
+    _send(user, uid, token)
 
 
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def send_password_reset_email(self, user_id: str, uid: str, token: str):
+def send_password_reset_email(user_id: str, uid: str, token: str):
     """Send password reset email."""
-    try:
-        from apps.accounts.models import User
-        user = User.objects.get(pk=user_id)
-        from apps.notifications.email import send_password_reset_email as _send
-        _send(user, uid, token)
-    except Exception as exc:
-        logger.exception('send_password_reset_email failed for user %s', user_id)
-        raise self.retry(exc=exc)
+    from apps.accounts.models import User
+    user = User.objects.get(pk=user_id)
+    from apps.notifications.email import send_password_reset_email as _send
+    _send(user, uid, token)
 
 
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def send_match_notification(self, match_id: str):
+def send_match_notification(match_id: str):
     """Email + in-app notification for all participants in a new match."""
-    try:
-        from apps.matching.models import Match
-        from apps.notifications.models import Notification
+    from apps.matching.models import Match
+    from apps.notifications.models import Notification
 
-        match = Match.objects.prefetch_related('legs__sender', 'legs__receiver').get(pk=match_id)
+    match = Match.objects.prefetch_related('legs__sender', 'legs__receiver').get(pk=match_id)
 
-        # Collect unique senders (they need to accept)
-        participants = set()
-        for leg in match.legs.all():
-            participants.add(leg.sender)
+    # Collect unique senders (they need to accept)
+    participants = set()
+    for leg in match.legs.all():
+        participants.add(leg.sender)
 
-        for user in participants:
-            # In-app notification
-            Notification.objects.create(
-                user=user,
-                notification_type='new_match',
-                title='New book match!',
-                body=(
-                    'You have a new book match. Log in to accept or decline.'
-                    if match.match_type == 'direct'
-                    else f'You are part of a {match.legs.count()}-way exchange ring!'
-                ),
-                metadata={'match_id': str(match.pk)},
-            )
-
-            # Email
-            from apps.notifications.email import send_match_notification_email
-            send_match_notification_email(user, match)
-
-    except Exception as exc:
-        logger.exception('send_match_notification failed for match %s', match_id)
-        raise self.retry(exc=exc)
-
-
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def send_trade_confirmed_notification(self, trade_id: str):
-    """Email all parties when a trade is confirmed."""
-    try:
-        from apps.trading.models import Trade
-        trade = Trade.objects.prefetch_related('shipments__sender', 'shipments__receiver').get(pk=trade_id)
-
-        parties = set()
-        for shipment in trade.shipments.all():
-            parties.add(shipment.sender)
-            parties.add(shipment.receiver)
-
-        for user in parties:
-            from apps.notifications.email import send_trade_confirmed_email
-            send_trade_confirmed_email(user, trade)
-
-    except Exception as exc:
-        logger.exception('send_trade_confirmed_notification failed for trade %s', trade_id)
-        raise self.retry(exc=exc)
-
-
-@shared_task(bind=True, max_retries=2, default_retry_delay=300)
-def send_rating_reminder(self, trade_id: str, user_id: str):
-    """Send a weekly rating reminder to a specific user for a trade."""
-    try:
-        from apps.accounts.models import User
-        from apps.trading.models import Trade
-        user = User.objects.get(pk=user_id)
-        trade = Trade.objects.get(pk=trade_id)
-        from apps.notifications.email import send_rating_reminder_email
-        send_rating_reminder_email(user, trade)
-    except Exception as exc:
-        logger.exception('send_rating_reminder failed for trade %s, user %s', trade_id, user_id)
-        raise self.retry(exc=exc)
-
-
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def send_inactivity_warning_1m(self, user_id: str):
-    """Send 1-month inactivity warning."""
-    try:
-        from apps.accounts.models import User
-        user = User.objects.get(pk=user_id)
-        from apps.notifications.email import send_inactivity_warning_1m_email
-        send_inactivity_warning_1m_email(user)
-        user.inactivity_warned_1m = timezone.now()
-        user.save(update_fields=['inactivity_warned_1m'])
-    except Exception as exc:
-        logger.exception('send_inactivity_warning_1m failed for user %s', user_id)
-        raise self.retry(exc=exc)
-
-
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def send_inactivity_warning_2m(self, user_id: str):
-    """Send 2-month inactivity warning."""
-    try:
-        from apps.accounts.models import User
-        user = User.objects.get(pk=user_id)
-        from apps.notifications.email import send_inactivity_warning_2m_email
-        send_inactivity_warning_2m_email(user)
-        user.inactivity_warned_2m = timezone.now()
-        user.save(update_fields=['inactivity_warned_2m'])
-    except Exception as exc:
-        logger.exception('send_inactivity_warning_2m failed for user %s', user_id)
-        raise self.retry(exc=exc)
-
-
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def send_books_delisted_notification(self, user_id: str):
-    """Send notification that books have been delisted."""
-    try:
-        from apps.accounts.models import User
-        from apps.notifications.models import Notification
-        user = User.objects.get(pk=user_id)
-        from apps.notifications.email import send_books_delisted_email
-        send_books_delisted_email(user)
+    for user in participants:
+        # In-app notification
         Notification.objects.create(
             user=user,
-            notification_type='books_delisted',
-            title='Your books have been delisted',
-            body='Your books have been temporarily removed due to inactivity. Log in to re-list them.',
+            notification_type='new_match',
+            title='New book match!',
+            body=(
+                'You have a new book match. Log in to accept or decline.'
+                if match.match_type == 'direct'
+                else f'You are part of a {match.legs.count()}-way exchange ring!'
+            ),
+            metadata={'match_id': str(match.pk)},
         )
-    except Exception as exc:
-        logger.exception('send_books_delisted_notification failed for user %s', user_id)
-        raise self.retry(exc=exc)
+
+        # Email
+        from apps.notifications.email import send_match_notification_email
+        send_match_notification_email(user, match)
 
 
-@shared_task(bind=True, max_retries=3, default_retry_delay=60)
-def send_account_deletion_initiated(self, user_id: str):
+def send_trade_confirmed_notification(trade_id: str):
+    """Email all parties when a trade is confirmed."""
+    from apps.trading.models import Trade
+    trade = Trade.objects.prefetch_related('shipments__sender', 'shipments__receiver').get(pk=trade_id)
+
+    parties = set()
+    for shipment in trade.shipments.all():
+        parties.add(shipment.sender)
+        parties.add(shipment.receiver)
+
+    for user in parties:
+        from apps.notifications.email import send_trade_confirmed_email
+        send_trade_confirmed_email(user, trade)
+
+
+def send_rating_reminder(trade_id: str, user_id: str):
+    """Send a weekly rating reminder to a specific user for a trade."""
+    from apps.accounts.models import User
+    from apps.trading.models import Trade
+    user = User.objects.get(pk=user_id)
+    trade = Trade.objects.get(pk=trade_id)
+    from apps.notifications.email import send_rating_reminder_email
+    send_rating_reminder_email(user, trade)
+
+
+def send_inactivity_warning_1m(user_id: str):
+    """Send 1-month inactivity warning."""
+    from apps.accounts.models import User
+    user = User.objects.get(pk=user_id)
+    from apps.notifications.email import send_inactivity_warning_1m_email
+    send_inactivity_warning_1m_email(user)
+    user.inactivity_warned_1m = timezone.now()
+    user.save(update_fields=['inactivity_warned_1m'])
+
+
+def send_inactivity_warning_2m(user_id: str):
+    """Send 2-month inactivity warning."""
+    from apps.accounts.models import User
+    user = User.objects.get(pk=user_id)
+    from apps.notifications.email import send_inactivity_warning_2m_email
+    send_inactivity_warning_2m_email(user)
+    user.inactivity_warned_2m = timezone.now()
+    user.save(update_fields=['inactivity_warned_2m'])
+
+
+def send_books_delisted_notification(user_id: str):
+    """Send notification that books have been delisted."""
+    from apps.accounts.models import User
+    from apps.notifications.models import Notification
+    user = User.objects.get(pk=user_id)
+    from apps.notifications.email import send_books_delisted_email
+    send_books_delisted_email(user)
+    Notification.objects.create(
+        user=user,
+        notification_type='books_delisted',
+        title='Your books have been delisted',
+        body='Your books have been temporarily removed due to inactivity. Log in to re-list them.',
+    )
+
+
+def send_account_deletion_initiated(user_id: str):
     """Send account deletion confirmation email with data export."""
-    try:
-        from apps.accounts.models import User
-        user = User.objects.get(pk=user_id)
-        from apps.notifications.email import send_account_deletion_email
-        send_account_deletion_email(user)
-    except Exception as exc:
-        logger.exception('send_account_deletion_initiated failed for user %s', user_id)
-        raise self.retry(exc=exc)
+    from apps.accounts.models import User
+    user = User.objects.get(pk=user_id)
+    from apps.notifications.email import send_account_deletion_email
+    send_account_deletion_email(user)
 
 
-@shared_task
 def check_inactivity():
     """
     Daily task: scan all users and send inactivity warnings / delist books.
@@ -184,6 +135,7 @@ def check_inactivity():
     from apps.accounts.models import User
     from apps.inventory.models import UserBook
     from datetime import timedelta
+    from django_q.tasks import async_task
 
     now = timezone.now()
     one_month_ago = now - timedelta(days=30)
@@ -203,7 +155,7 @@ def check_inactivity():
         )
         user.books_delisted_at = now
         user.save(update_fields=['books_delisted_at'])
-        send_books_delisted_notification.delay(str(user.pk))
+        async_task('apps.notifications.tasks.send_books_delisted_notification', str(user.pk))
         logger.info('Delisted books for inactive user %s', user.pk)
 
     # Users inactive for 2+ months with 1m warning sent → send 2m warning
@@ -215,7 +167,7 @@ def check_inactivity():
         books_delisted_at__isnull=True,
     )
     for user in to_warn_2m:
-        send_inactivity_warning_2m.delay(str(user.pk))
+        async_task('apps.notifications.tasks.send_inactivity_warning_2m', str(user.pk))
         logger.info('Sent 2m inactivity warning to user %s', user.pk)
 
     # Users inactive for 1+ month with no warning sent → send 1m warning
@@ -226,5 +178,5 @@ def check_inactivity():
         books_delisted_at__isnull=True,
     )
     for user in to_warn_1m:
-        send_inactivity_warning_1m.delay(str(user.pk))
+        async_task('apps.notifications.tasks.send_inactivity_warning_1m', str(user.pk))
         logger.info('Sent 1m inactivity warning to user %s', user.pk)

--- a/apps/trading/services/trade_workflow.py
+++ b/apps/trading/services/trade_workflow.py
@@ -38,8 +38,8 @@ def create_trade_from_match(match) -> 'Trade':
 
     # Notify all parties
     try:
-        from apps.notifications.tasks import send_trade_confirmed_notification
-        send_trade_confirmed_notification.delay(str(trade.pk))
+        from django_q.tasks import async_task
+        async_task('apps.notifications.tasks.send_trade_confirmed_notification', str(trade.pk))
     except Exception:
         logger.exception('Failed to queue trade confirmed notification for trade %s', trade.pk)
 
@@ -80,8 +80,8 @@ def create_trade_from_proposal(proposal) -> 'Trade':
         )
 
     try:
-        from apps.notifications.tasks import send_trade_confirmed_notification
-        send_trade_confirmed_notification.delay(str(trade.pk))
+        from django_q.tasks import async_task
+        async_task('apps.notifications.tasks.send_trade_confirmed_notification', str(trade.pk))
     except Exception:
         logger.exception('Failed to queue trade confirmed notification for trade %s', trade.pk)
 

--- a/apps/trading/tasks.py
+++ b/apps/trading/tasks.py
@@ -1,12 +1,10 @@
 import logging
 
-from celery import shared_task
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
 
-@shared_task
 def send_rating_reminders():
     """
     Weekly task: send rating reminders to users who haven't rated yet.
@@ -14,6 +12,7 @@ def send_rating_reminders():
     """
     from apps.trading.models import Trade, TradeShipment
     from apps.ratings.models import Rating
+    from django_q.tasks import async_task
 
     # Find completed/shipping trades that still need ratings
     active_statuses = [
@@ -44,8 +43,7 @@ def send_rating_reminders():
 
         for uid in unrated_user_ids:
             try:
-                from apps.notifications.tasks import send_rating_reminder
-                send_rating_reminder.delay(str(trade.pk), uid)
+                async_task('apps.notifications.tasks.send_rating_reminder', str(trade.pk), uid)
             except Exception:
                 logger.exception('Failed to queue rating reminder for trade %s, user %s', trade.pk, uid)
 
@@ -53,7 +51,6 @@ def send_rating_reminders():
         trade.save(update_fields=['rating_reminders_sent'])
 
 
-@shared_task
 def auto_close_trades():
     """
     Weekly task: close trades that have passed their auto_close_at deadline.

--- a/config/celery.py
+++ b/config/celery.py
@@ -1,9 +1,0 @@
-import os
-
-from celery import Celery
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.development')
-
-app = Celery('bookforbook')
-app.config_from_object('django.conf:settings', namespace='CELERY')
-app.autodiscover_tasks()

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -26,7 +26,7 @@ THIRD_PARTY_APPS = [
     'rest_framework_simplejwt',
     'rest_framework_simplejwt.token_blacklist',
     'corsheaders',
-    'django_celery_beat',
+    'django_q',
     'django_filters',
 ]
 
@@ -155,15 +155,17 @@ CORS_ALLOWED_ORIGINS = config(
 )
 CORS_ALLOW_CREDENTIALS = True
 
-# Celery
-REDIS_URL = config('REDIS_URL', default='redis://localhost:6379/0')
-CELERY_BROKER_URL = REDIS_URL
-CELERY_RESULT_BACKEND = REDIS_URL
-CELERY_ACCEPT_CONTENT = ['json']
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
-CELERY_TIMEZONE = TIME_ZONE
-CELERY_BEAT_SCHEDULER = 'django_celery_beat.schedulers:DatabaseScheduler'
+# Django-Q2 (uses PostgreSQL as broker — no Redis needed)
+Q_CLUSTER = {
+    'name': 'bookforbook',
+    'workers': 1,
+    'timeout': 300,
+    'retry': 360,
+    'orm': 'default',
+    'catch_up': False,
+    'max_attempts': 3,
+    'ack_failures': True,
+}
 
 # Encrypted model fields
 FIELD_ENCRYPTION_KEY = config('FIELD_ENCRYPTION_KEY', default='')

--- a/docs/bookswap-architecture.md
+++ b/docs/bookswap-architecture.md
@@ -12,13 +12,13 @@ BookForBook is a book bartering platform where users trade books 1-for-1 without
 |-------|-----------|-----------|
 | Backend framework | Django 5.x + Django REST Framework | Auth, ORM, admin panel out of the box; strong Python ecosystem |
 | Database | PostgreSQL 16 | Relational data model, full-text search, JSON fields for flexibility |
-| Task queue | Celery + Redis | Background matching engine, email notifications, ISBN enrichment |
+| Task queue | Django-Q2 (PostgreSQL broker) | Background matching engine, email notifications, ISBN enrichment |
 | Frontend | React 18 (Vite) as PWA | Interactive browsing, trade flows; PWA for mobile access |
 | ISBN enrichment | Open Library API (free, no key required) | Title, author, cover image, publisher, year, page count |
 | Notifications | Email (Django + SendGrid/SES), SMS optional (Twilio) | Trade alerts, match notifications, shipping confirmations |
 | Search | PostgreSQL full-text search (upgrade to Meilisearch/Typesense if needed) | Book catalog browsing |
 | File storage | S3-compatible (AWS S3, Backblaze B2, or local for dev) | Cover image caching |
-| Deployment | Native (PostgreSQL + Redis installed directly on VPS) OR managed (Railway, Render) | Flexible based on preference |
+| Deployment | Native (PostgreSQL installed directly on VPS) OR managed (Railway, Render) | Flexible based on preference |
 
 ---
 
@@ -258,7 +258,7 @@ TradeShipment (one per direction in the trade)
 - Address is revealed to both parties at this point.
 - Each shipment is tracked independently — one side might ship before the other.
 - `one_received` means one party confirmed receipt; `completed` means both have.
-- **Auto-close logic:** After a match is accepted, a weekly Celery task sends rating reminders to users who haven't rated yet (up to 3 reminders). After 3 weeks with no rating, the trade is auto-closed with status `auto_closed` — the book is assumed received, UserBooks move to `traded`, and user trade counts are updated. No rating is recorded.
+- **Auto-close logic:** After a match is accepted, a weekly background task sends rating reminders to users who haven't rated yet (up to 3 reminders). After 3 weeks with no rating, the trade is auto-closed with status `auto_closed` — the book is assumed received, UserBooks move to `traded`, and user trade counts are updated. No rating is recorded.
 - **No dispute resolution.** The rating system is the only accountability mechanism. Users who send wrong books or don't ship will accumulate bad ratings.
 
 ### Ratings
@@ -282,7 +282,7 @@ UNIQUE CONSTRAINT: (trade_id, rater_id) — one rating per user per trade
 **Notes:**
 - Only the **last 10 ratings** are used for computing `avg_recent_rating` on the User profile.
 - Historical ratings are kept in the database but not surfaced publicly.
-- A Celery task or DB trigger recomputes the rolling average after each new rating.
+- A background task or DB trigger recomputes the rolling average after each new rating.
 - `book_condition_accurate` helps build trust signals beyond the star rating.
 
 ### Shipping Estimates
@@ -350,7 +350,7 @@ User enters ISBN
 - Cover image: `https://covers.openlibrary.org/b/isbn/{isbn}-M.jpg`
 - Search fallback: `https://openlibrary.org/search.json?isbn={isbn}`
 
-### 2. Matching Engine (Background — Celery)
+### 2. Matching Engine (Background — Django-Q2)
 
 **Runs on triggers:**
 - New UserBook or WishlistItem created
@@ -440,7 +440,7 @@ Individual browses institution's wanted list
 ```
 After a trade is confirmed:
     → Set auto_close_at = confirmed_at + 3 weeks
-    → Weekly Celery task checks all active trades:
+    → Weekly background task checks all active trades:
         → If user hasn't rated AND trade is still open:
             → Send rating reminder email (up to 3 per user)
             → Increment rating_reminders_sent
@@ -505,7 +505,7 @@ User registers with email + password
 ### 9. Inactivity Management
 
 ```
-Daily Celery task scans all users:
+Daily background task scans all users:
 
 1 month since last_active_at (no warning sent yet):
     → Send "We miss you" email with summary of any pending matches
@@ -646,7 +646,7 @@ User requests deletion → POST /api/v1/users/me/ (DELETE)
 | Account deletion initiated (30-day grace) | Email | Critical |
 | Account deletion completed | Email | Critical |
 
-**Implementation:** Celery tasks triggered by Django signals. Email via SendGrid or AWS SES. In-app via a simple Notification model polled by frontend (upgrade to WebSockets later if needed).
+**Implementation:** background tasks triggered by Django signals. Email via SendGrid or AWS SES. In-app via a simple Notification model polled by frontend (upgrade to WebSockets later if needed).
 
 ---
 
@@ -674,7 +674,7 @@ bookforbook/
 │   │   ├── development.py
 │   │   └── production.py
 │   ├── urls.py
-│   ├── celery.py
+│   ├── __init__.py
 │   └── wsgi.py
 │
 ├── apps/
@@ -731,7 +731,7 @@ bookforbook/
 │   │
 │   ├── notifications/          # Email, in-app notifications
 │       ├── models.py
-│       ├── tasks.py            # Celery tasks
+│       ├── tasks.py            # background tasks
 │       └── templates/          # Email templates
 │
 │   └── messaging/              # Structured trade messages
@@ -762,7 +762,7 @@ bookforbook/
 This architecture is designed to be built incrementally with Claude Code. Recommended build order:
 
 ### Phase 1 — Foundation
-1. Django project scaffold with settings (requires PostgreSQL 16 + Redis installed natively)
+1. Django project scaffold with settings (requires PostgreSQL 16 installed natively)
 2. Custom User model with account types and email verification fields
 3. Auth endpoints: register, login, email verification, password reset
 4. Book model + Open Library API service
@@ -774,7 +774,7 @@ This architecture is designed to be built incrementally with Claude Code. Recomm
 8. Browse available books with search/filter
 
 ### Phase 3 — Matching Engine
-9. Direct match detection service + Celery task
+9. Direct match detection service + background task
 10. Match model + notification on match
 11. Match limit enforcement (rating-based capacity)
 12. Accept/decline flow with address reveal
@@ -786,7 +786,7 @@ This architecture is designed to be built incrementally with Claude Code. Recomm
 16. Shipping estimate utility (Media Mail rate lookup by page count)
 17. Post-match partner browsing + additional proposals
 18. Rating system with rolling average
-19. Weekly rating reminder Celery task
+19. Weekly rating reminder background task
 20. 3-week auto-close logic for unrated trades
 
 ### Phase 5 — Institutions
@@ -801,7 +801,7 @@ This architecture is designed to be built incrementally with Claude Code. Recomm
 27. Ring trade execution
 
 ### Phase 7 — User Lifecycle
-28. Inactivity detection Celery task (1m/2m warnings, 3m delist)
+28. Inactivity detection background task (1m/2m warnings, 3m delist)
 29. Auto-relist on login after delisting
 30. GDPR data export endpoint
 31. Account deletion with 30-day grace period and anonymization

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,7 @@ Django==5.1.4
 djangorestframework==3.15.2
 djangorestframework-simplejwt==5.3.1
 django-cors-headers==4.4.0
-celery==5.4.0
-redis==5.1.1
-django-celery-beat==2.7.0
+django-q2==1.7.5
 psycopg2-binary==2.9.9
 cryptography==43.0.3
 django-encrypted-model-fields==0.6.5


### PR DESCRIPTION
Eliminates Redis as a dependency by switching the task queue to Django-Q2, which uses the existing PostgreSQL database as its broker. This simplifies deployment on shared hosting (SureSupport) where Redis is unavailable.

- Remove celery, redis, django-celery-beat from requirements; add django-q2
- Remove config/celery.py and celery import from config/__init__.py
- Replace CELERY_* settings with Q_CLUSTER config in base.py
- Convert all @shared_task functions to plain functions
- Replace all .delay() calls with django_q.tasks.async_task()
- Add data migration for periodic schedules (matching, inactivity, ratings, auto-close)
- Remove REDIS_URL from .env.example
- Update README, CLAUDE.md, and architecture docs

Startup: `python manage.py qcluster` replaces both celery worker and beat.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq