### PR TITLE
Add initial migration for Notification model

### DIFF
--- a/apps/notifications/migrations/0001_initial.py
+++ b/apps/notifications/migrations/0001_initial.py
@@ -1,0 +1,44 @@
+import uuid
+
+import django.db.models.deletion
+import django.utils.timezone
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Notification',
+            fields=[
+                ('id', models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ('notification_type', models.CharField(max_length=50)),
+                ('title', models.CharField(max_length=255)),
+                ('body', models.TextField()),
+                ('is_read', models.BooleanField(default=False)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('read_at', models.DateTimeField(blank=True, null=True)),
+                ('metadata', models.JSONField(default=dict)),
+                ('user', models.ForeignKey(
+                    on_delete=django.db.models.deletion.CASCADE,
+                    related_name='notifications',
+                    to=settings.AUTH_USER_MODEL,
+                )),
+            ],
+            options={
+                'verbose_name': 'Notification',
+                'verbose_name_plural': 'Notifications',
+                'ordering': ['-created_at'],
+            },
+        ),
+        migrations.AddIndex(
+            model_name='notification',
+            index=models.Index(fields=['user', 'is_read', 'created_at'], name='notificatio_user_id_is_read_idx'),
+        ),
+    ]

--- a/apps/notifications/migrations/0002_create_q_schedules.py
+++ b/apps/notifications/migrations/0002_create_q_schedules.py
@@ -54,6 +54,7 @@ def remove_schedules(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
+        ('notifications', '0001_initial'),
         ('django_q', '0001_initial'),
     ]
     operations = [


### PR DESCRIPTION
The notifications app was missing its initial model migration. Also renumbered the Q schedules migration to 0002 and added the proper dependency chain.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq