### PR TITLE
Add user-facing README and superuser guide; move setup docs to SETUP.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,196 +1,464 @@
 # BookForBook
 
-A book bartering platform where users in the continental USA trade books 1-for-1 — no money changes hands.
+**Trade books, not money.** BookForBook is a free platform for people in the continental USA to swap books 1-for-1. No payments, no credits — just books changing hands between people who want them.
+
+---
+
+## Table of Contents
+
+- [How It Works](#how-it-works)
+- [For the General Public — Browsing Without an Account](#for-the-general-public--browsing-without-an-account)
+- [For Individual Traders](#for-individual-traders)
+  - [Getting Started](#getting-started-as-a-trader)
+  - [Listing Books You Want to Give Away](#listing-books-you-want-to-give-away)
+  - [Building Your Want List](#building-your-want-list)
+  - [When a Match is Found](#when-a-match-is-found)
+  - [Exchange Rings (Multi-Party Trades)](#exchange-rings-multi-party-trades)
+  - [Proposing a Trade Directly](#proposing-a-trade-directly)
+  - [Shipping Your Book](#shipping-your-book)
+  - [Leaving a Rating](#leaving-a-rating)
+  - [Your Profile and Reputation](#your-profile-and-reputation)
+  - [Account Inactivity](#account-inactivity)
+  - [Deleting Your Account](#deleting-your-account)
+- [For Libraries and Bookstores](#for-libraries-and-bookstores)
+  - [Getting Approved](#getting-approved)
+  - [Managing Your Wanted List](#managing-your-wanted-list)
+  - [Receiving Donations](#receiving-donations)
+- [Key Rules](#key-rules)
+- [FAQ](#faq)
+
+---
 
 ## How It Works
 
-1. List books you want to give away (by ISBN) with a condition rating
-2. Add books to your want list
-3. The system automatically detects mutual matches and exchange rings (up to 5 people)
-4. All parties confirm the trade; shipping addresses are revealed only then
-5. Ship your book, mark it received, and leave a rating
+1. You list books you want to give away (by ISBN) and rate their condition
+2. You add books to your want list
+3. The system scans for matches — either direct (you have what someone else wants, and they have what you want) or rings (a chain of 3–5 people who can all trade with each other)
+4. When a match is found, all parties are notified and must confirm
+5. Once everyone confirms, shipping addresses are revealed
+6. You ship your book via USPS Media Mail, mark it sent, then mark it received when it arrives
+7. Leave a rating — your reputation on the platform is built from your last 10 ratings
 
-Verified libraries and bookstores can receive book donations.
+---
 
-## Tech Stack
+## For the General Public — Browsing Without an Account
 
-| Layer | Technology |
-|---|---|
-| Backend | Django 5.x + Django REST Framework |
-| Database | PostgreSQL 16 |
-| Task queue | Django-Q2 (PostgreSQL broker) |
-| Frontend | React 18 (Vite) as PWA |
-| ISBN data | Open Library API |
-| Auth | JWT (djangorestframework-simplejwt) |
-| File storage | S3-compatible |
-| Notifications | Email (SendGrid/AWS SES), optional SMS (Twilio) |
+You do not need an account to browse available books.
 
-## Getting Started
+**What you can do without signing up:**
+- Browse all books currently available for trade at `/api/v1/browse/available/`
+- Search by title, author, or ISBN: `/api/v1/browse/available/?q=tolkien`
+- Filter by condition: `/api/v1/browse/available/?condition=like_new`
+- View public profiles of traders at `/api/v1/users/{user_id}/`
+- View a trader's ratings at `/api/v1/users/{user_id}/ratings/`
+- Browse verified libraries and bookstores at `/api/v1/institutions/`
+- See what a specific institution is looking for at `/api/v1/institutions/{id}/wanted/`
+- Get a shipping cost estimate for any listed book at `/api/v1/browse/shipping-estimate/{book_id}/`
 
-### Prerequisites
+**What requires an account:**
+- Listing books, adding to your want list, accepting matches, and trading
 
-- Python 3.12+
-- Node.js 20+
-- PostgreSQL 16 — set up via `setup_postgres.sh` (see below)
+---
 
-### 1. Set up PostgreSQL
+## For Individual Traders
 
-Run the setup script once to create a managed PostgreSQL instance:
+### Getting Started as a Trader
 
-```bash
-sh setup_postgres.sh
-```
-
-This creates a PostgreSQL instance at `~/private/postgres1/` running on a Unix socket
-(no TCP port — this is normal for this hosting environment).
-
-Load the environment variables it configures:
-
-```bash
-source ~/apps/postgres1/home/.bashrc
-```
-
-> Add that `source` line to your shell's `~/.bashrc` (or `~/.profile`) so `PGHOST` is set
-> automatically on every login.
-
-Verify the instance is running and you can connect:
-
-```bash
-psql postgres -c "\conninfo"
-```
-
-Create the application database and user:
-
-```bash
-# Generate a strong password
-python3 -c "import secrets; print(secrets.token_urlsafe(32))"
-
-# Create the user (replace YOUR_PASSWORD with the generated password)
-psql postgres -c "CREATE USER bookforbook WITH PASSWORD 'YOUR_PASSWORD';"
-
-# Create the database owned by that user
-psql postgres -c "CREATE DATABASE bookforbook OWNER bookforbook;"
-
-# Grant schema permissions
-psql bookforbook -c "GRANT ALL ON SCHEMA public TO bookforbook;"
-```
-
-Note your socket directory — you'll need it for `.env`:
-
-```bash
-echo $PGHOST
-# e.g. /home/yourusername/private/postgres1/run
-```
-
-### 2. Configure environment
-
-```bash
-cp .env.example .env
-```
-
-Edit `.env` and set at minimum:
+**1. Register**
 
 ```
-SECRET_KEY=<generate with: python3 -c "import secrets; print(secrets.token_urlsafe(50))">
-DATABASE_URL=postgresql://bookforbook:YOUR_PASSWORD@/bookforbook?host=/home/YOUR_USERNAME/private/postgres1/run
-FIELD_ENCRYPTION_KEY=<generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())">
-ALLOWED_HOSTS=yourdomain.com
-FRONTEND_URL=https://yourdomain.com
+POST /api/v1/auth/register/
+{
+  "username": "yourname",
+  "email": "you@example.com",
+  "password": "yourpassword"
+}
 ```
 
-Replace `/home/YOUR_USERNAME/private/postgres1/run` with the actual path from `echo $PGHOST`.
+You will receive a verification email. You must verify your email before you can list books or trade.
 
-### 3. Install dependencies and run migrations
+**2. Verify your email**
 
-```bash
-python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt
-python manage.py makemigrations accounts
-python manage.py migrate
-python manage.py createsuperuser
-```
-
-### 4. Start the application
-
-```bash
-# Django dev server
-python manage.py runserver
-
-# Periodic tasks are run via cron (no qcluster needed on shared hosting)
-# See apps/notifications/management/commands/run_periodic_tasks.py for crontab entries
-```
-
-### 5. Frontend
-
-```bash
-cd frontend
-npm install
-npm run dev
-```
-
-### Seed development data
-
-```bash
-python scripts/seed_data.py
-```
-
-## API
-
-All endpoints live under `/api/v1/`. JWT auth is required except for browse/search and public profiles.
-
-| Prefix | Description |
-|---|---|
-| `auth/` | Register, verify email, login, refresh token, password reset |
-| `users/` | Profile, ratings, GDPR export/delete |
-| `books/` | ISBN lookup, search |
-| `my-books/` | Have-list management |
-| `wishlist/` | Want-list management |
-| `matches/` | Auto-detected matches; accept/decline |
-| `proposals/` | User-initiated trade proposals |
-| `trades/` | Shipment tracking, messaging, ratings |
-| `donations/` | Institutional donation workflow |
-| `institutions/` | Library/bookstore directory |
-| `browse/` | Public book discovery, shipping estimates |
-
-## Project Structure
+Click the link in the verification email, or submit the token directly:
 
 ```
-bookforbook/
-├── config/                  # Django project settings, URLs
-├── apps/
-│   ├── accounts/            # User model, auth, profiles
-│   ├── books/               # Book cache, ISBN lookup, Open Library client
-│   ├── inventory/           # Have-list (UserBook) and want-list (WishlistItem)
-│   ├── matching/            # Direct match + exchange ring detection
-│   ├── trading/             # Proposals, trades, shipment tracking
-│   ├── donations/           # Institutional donation workflow
-│   ├── ratings/             # 1-5 star ratings with rolling average
-│   ├── notifications/       # Email/in-app notifications via Django-Q2
-│   └── messaging/           # Structured trade messages
-├── frontend/                # React PWA (Vite)
-├── scripts/                 # Dev utilities (seed data)
-└── docs/                    # Architecture specification
+POST /api/v1/auth/verify-email/
+{
+  "uid": "...",
+  "token": "..."
+}
 ```
 
-## Running Tests
+**3. Log in**
 
-```bash
-pytest
+```
+POST /api/v1/auth/login/
+{
+  "email": "you@example.com",
+  "password": "yourpassword"
+}
 ```
 
-## Key Business Rules
+Returns `access` and `refresh` JWT tokens. Include the access token in all subsequent requests:
 
-- **1-for-1 only** — every trade is exactly one book in each direction
-- **Continental USA only** — shipping addresses validated to continental US states
-- **Match capacity** — new users get 1 active match slot; grows to 10 with trading history
-- **Address privacy** — shipping addresses are encrypted at rest and revealed only to confirmed trade partners
-- **Exchange rings** — the system detects cycles of 3–5 users who can all trade with each other
-- **Inactivity** — books are auto-hidden after 3 months of inactivity and restored on next login
+```
+Authorization: Bearer <access_token>
+```
 
-## Docs
+**4. Complete your profile**
 
-See [`docs/bookswap-architecture.md`](docs/bookswap-architecture.md) for the full architecture specification and 8-phase build roadmap.
+Add your shipping address — this is required before any trade can be confirmed. Your address is encrypted and only revealed to confirmed trade partners.
 
-## License
+```
+PATCH /api/v1/users/me/
+{
+  "full_name": "Jane Smith",
+  "address_line_1": "123 Main St",
+  "city": "Portland",
+  "state": "OR",
+  "zip_code": "97201"
+}
+```
 
-MIT
+Only continental US states are accepted.
+
+---
+
+### Listing Books You Want to Give Away
+
+Add a book to your have-list by ISBN. The system looks up the title, author, and cover from Open Library automatically.
+
+```
+POST /api/v1/my-books/
+{
+  "isbn": "9780261103573",
+  "condition": "very_good"
+}
+```
+
+Condition options: `like_new`, `very_good`, `good`, `acceptable`
+
+**View your have-list:**
+```
+GET /api/v1/my-books/
+```
+
+**Update a book's condition:**
+```
+PATCH /api/v1/my-books/{id}/
+{
+  "condition": "good"
+}
+```
+
+**Remove a book** (only if not currently reserved or in a trade):
+```
+DELETE /api/v1/my-books/{id}/
+```
+
+You can list multiple copies of the same ISBN — each is tracked separately.
+
+---
+
+### Building Your Want List
+
+```
+POST /api/v1/wishlist/
+{
+  "isbn": "9780743273565",
+  "min_condition": "good"
+}
+```
+
+`min_condition` sets the lowest condition you'll accept. The system will only match you with books that meet this threshold.
+
+**View your want list:**
+```
+GET /api/v1/wishlist/
+```
+
+**Update minimum condition:**
+```
+PATCH /api/v1/wishlist/{id}/
+{
+  "min_condition": "very_good"
+}
+```
+
+**Remove a want:**
+```
+DELETE /api/v1/wishlist/{id}/
+```
+
+---
+
+### When a Match is Found
+
+The matching engine runs automatically every 6 hours and whenever you add a new book or want. When a match is found:
+
+1. You receive an email notification and an in-app notification
+2. Log in and view your matches: `GET /api/v1/matches/`
+3. Review the match details — who you're trading with, which book you're giving, which you're getting
+4. **Accept:** `POST /api/v1/matches/{id}/accept/`
+5. **Decline:** `POST /api/v1/matches/{id}/decline/`
+
+A match only proceeds if **all** parties accept. If anyone declines, the match is cancelled and the books return to available status.
+
+Once all parties accept, the trade is confirmed and shipping addresses are revealed automatically.
+
+**New users start with 1 active match slot.** This grows up to 10 as you accumulate ratings.
+
+---
+
+### Exchange Rings (Multi-Party Trades)
+
+Sometimes a direct swap isn't possible, but a chain works: Alice has what Bob wants, Bob has what Carol wants, Carol has what Alice wants. The system detects these cycles automatically (up to 5 people).
+
+Ring trades work the same as direct trades — everyone must accept, everyone ships to the next person in the ring. If one person declines, the system attempts to reform the ring with other users before cancelling.
+
+---
+
+### Proposing a Trade Directly
+
+If you see a book you want listed by another user (visible in browse), you can propose a trade directly without waiting for the matching engine.
+
+```
+POST /api/v1/proposals/
+{
+  "recipient_id": "user-uuid",
+  "items": [
+    {
+      "user_book_id": "their-book-uuid",
+      "direction": "recipient_sends"
+    },
+    {
+      "user_book_id": "your-book-uuid",
+      "direction": "proposer_sends"
+    }
+  ]
+}
+```
+
+Proposals are always 1-for-1. The recipient can accept, decline, or counter-offer. You can counter their counter-offer. A trade is created when one party accepts.
+
+**View your proposals:**
+```
+GET /api/v1/proposals/
+```
+
+---
+
+### Shipping Your Book
+
+Once a trade is confirmed, view your trade details including the recipient's shipping address:
+
+```
+GET /api/v1/trades/{id}/
+```
+
+Ship via **USPS Media Mail** — the cheapest option for books (typically $4–6 for the first pound). Keep your tracking number.
+
+**Mark as shipped:**
+```
+POST /api/v1/trades/{id}/mark-shipped/
+{
+  "shipment_id": "shipment-uuid",
+  "tracking_number": "9400111899223456789012",
+  "shipping_method": "USPS Media Mail"
+}
+```
+
+**When your book arrives, mark it received:**
+```
+POST /api/v1/trades/{id}/mark-received/
+{
+  "shipment_id": "shipment-uuid"
+}
+```
+
+Once both shipments are marked received, the trade is complete.
+
+---
+
+### Leaving a Rating
+
+After a trade completes you can rate the other person (1–5 stars):
+
+```
+POST /api/v1/trades/{id}/rate/
+{
+  "score": 5,
+  "book_condition_accurate": true,
+  "comment": "Book was exactly as described. Fast shipping!"
+}
+```
+
+- Ratings are based on your last 10 received — your score reflects recent behavior
+- Rating reminders are sent weekly for up to 3 weeks
+- Trades auto-close after 3 weeks with no rating (books marked traded, no score recorded)
+
+---
+
+### Your Profile and Reputation
+
+```
+GET /api/v1/users/me/
+```
+
+Your public profile (visible to anyone):
+```
+GET /api/v1/users/{id}/
+```
+
+Your ratings:
+```
+GET /api/v1/users/{id}/ratings/
+```
+
+**Export your data** (GDPR):
+```
+GET /api/v1/users/me/export/
+```
+
+---
+
+### Account Inactivity
+
+If you don't log in:
+- **After 1 month:** warning email
+- **After 2 months:** second warning
+- **After 3 months:** your books are hidden from matching (but not deleted)
+
+Log back in at any time to automatically restore your books and resume matching.
+
+---
+
+### Deleting Your Account
+
+```
+DELETE /api/v1/users/me/
+{
+  "password": "yourpassword"
+}
+```
+
+Your data export is emailed to you. Active matches and proposals are cancelled. Account is deactivated immediately (30-day grace period before full deletion).
+
+---
+
+## For Libraries and Bookstores
+
+Libraries and bookstores participate differently from individual traders — they **receive donations only**. They do not trade or ship books out.
+
+### Getting Approved
+
+1. Register with `account_type` set to `library` or `bookstore`:
+
+```
+POST /api/v1/auth/register/
+{
+  "username": "portland_public_library",
+  "email": "books@portlandlibrary.org",
+  "password": "yourpassword",
+  "account_type": "library",
+  "institution_name": "Portland Public Library"
+}
+```
+
+2. Your account is created but **inactive** until a platform administrator approves it via the admin panel. You will receive an email when approved.
+
+3. Verify your email address (same as individual users).
+
+### Managing Your Wanted List
+
+Once approved, build a list of books your institution is looking for. This list is public.
+
+```
+POST /api/v1/wishlist/
+{
+  "isbn": "9780525559474",
+  "min_condition": "acceptable"
+}
+```
+
+View your institution's public wanted list (visible to anyone without login):
+```
+GET /api/v1/institutions/{id}/wanted/
+```
+
+### Receiving Donations
+
+Individual users can offer a donation directly to your institution:
+
+```
+POST /api/v1/donations/
+{
+  "institution_id": "library-uuid",
+  "user_book_id": "book-uuid"
+}
+```
+
+You review incoming donation offers:
+```
+GET /api/v1/donations/
+```
+
+**Accept:**
+```
+POST /api/v1/donations/{id}/accept/
+```
+
+**Decline:**
+```
+POST /api/v1/donations/{id}/decline/
+```
+
+Once accepted, the donor ships the book to your institution. No address reveal is needed on your end — the donor sees your institution's public address.
+
+---
+
+## Key Rules
+
+| Rule | Detail |
+|------|--------|
+| 1-for-1 only | Every trade is exactly one book in each direction |
+| Continental USA only | Shipping addresses must be in the 48 continental states (no Hawaii, Alaska, territories) |
+| Email verification | Required before listing books, matching, or trading. Browsing is open to all. |
+| Match capacity | New users: 1 active match slot. Grows to 10 with trading history. |
+| Address privacy | Shipping addresses are encrypted and only revealed to confirmed trade partners |
+| Ring size | Exchange rings are capped at 5 participants |
+| Auto-close | Trades auto-close 3 weeks after confirmation if no ratings are submitted |
+| Inactivity | Books hidden after 3 months inactive; restored on next login |
+| No disputes | The rating system is the sole accountability mechanism. There is no dispute resolution. |
+| Institutional accounts | Libraries and bookstores require admin approval and can only receive donations |
+
+---
+
+## FAQ
+
+**Do I pay anything?**
+No. The platform is free. You pay only your own shipping costs (typically $4–6 USPS Media Mail per book).
+
+**What if the book I receive is not as described?**
+Leave an honest rating. There is no formal dispute process — the rating system is how accountability works on this platform.
+
+**Can I trade the same book twice?**
+Yes. Add it to your have-list again after the first trade completes.
+
+**What if the other person never ships?**
+The trade auto-closes after 3 weeks. Their rating (or lack thereof) reflects this. You can leave a 1-star rating with a note.
+
+**Can I be in multiple trades at once?**
+Yes, up to your match capacity (1 slot for new users, up to 10 as you build history).
+
+**What if I'm in a ring and someone declines?**
+The system attempts to reform the ring without that person. If it can't, the ring is cancelled and all books return to available.
+
+**How do I find a specific book?**
+Browse: `GET /api/v1/browse/available/?q=great+gatsby`
+
+**What condition ratings mean:**
+- `like_new` — unread or near perfect
+- `very_good` — minor signs of wear, no damage
+- `good` — some wear, all pages intact
+- `acceptable` — heavy wear, may have notes/highlighting, fully readable

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,196 @@
+# BookForBook
+
+A book bartering platform where users in the continental USA trade books 1-for-1 — no money changes hands.
+
+## How It Works
+
+1. List books you want to give away (by ISBN) with a condition rating
+2. Add books to your want list
+3. The system automatically detects mutual matches and exchange rings (up to 5 people)
+4. All parties confirm the trade; shipping addresses are revealed only then
+5. Ship your book, mark it received, and leave a rating
+
+Verified libraries and bookstores can receive book donations.
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Backend | Django 5.x + Django REST Framework |
+| Database | PostgreSQL 16 |
+| Task queue | Django-Q2 (PostgreSQL broker) |
+| Frontend | React 18 (Vite) as PWA |
+| ISBN data | Open Library API |
+| Auth | JWT (djangorestframework-simplejwt) |
+| File storage | S3-compatible |
+| Notifications | Email (SendGrid/AWS SES), optional SMS (Twilio) |
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.12+
+- Node.js 20+
+- PostgreSQL 16 — set up via `setup_postgres.sh` (see below)
+
+### 1. Set up PostgreSQL
+
+Run the setup script once to create a managed PostgreSQL instance:
+
+```bash
+sh setup_postgres.sh
+```
+
+This creates a PostgreSQL instance at `~/private/postgres1/` running on a Unix socket
+(no TCP port — this is normal for this hosting environment).
+
+Load the environment variables it configures:
+
+```bash
+source ~/apps/postgres1/home/.bashrc
+```
+
+> Add that `source` line to your shell's `~/.bashrc` (or `~/.profile`) so `PGHOST` is set
+> automatically on every login.
+
+Verify the instance is running and you can connect:
+
+```bash
+psql postgres -c "\conninfo"
+```
+
+Create the application database and user:
+
+```bash
+# Generate a strong password
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+
+# Create the user (replace YOUR_PASSWORD with the generated password)
+psql postgres -c "CREATE USER bookforbook WITH PASSWORD 'YOUR_PASSWORD';"
+
+# Create the database owned by that user
+psql postgres -c "CREATE DATABASE bookforbook OWNER bookforbook;"
+
+# Grant schema permissions
+psql bookforbook -c "GRANT ALL ON SCHEMA public TO bookforbook;"
+```
+
+Note your socket directory — you'll need it for `.env`:
+
+```bash
+echo $PGHOST
+# e.g. /home/yourusername/private/postgres1/run
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set at minimum:
+
+```
+SECRET_KEY=<generate with: python3 -c "import secrets; print(secrets.token_urlsafe(50))">
+DATABASE_URL=postgresql://bookforbook:YOUR_PASSWORD@/bookforbook?host=/home/YOUR_USERNAME/private/postgres1/run
+FIELD_ENCRYPTION_KEY=<generate with: python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())">
+ALLOWED_HOSTS=yourdomain.com
+FRONTEND_URL=https://yourdomain.com
+```
+
+Replace `/home/YOUR_USERNAME/private/postgres1/run` with the actual path from `echo $PGHOST`.
+
+### 3. Install dependencies and run migrations
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+python manage.py makemigrations accounts
+python manage.py migrate
+python manage.py createsuperuser
+```
+
+### 4. Start the application
+
+```bash
+# Django dev server
+python manage.py runserver
+
+# Periodic tasks are run via cron (no qcluster needed on shared hosting)
+# See apps/notifications/management/commands/run_periodic_tasks.py for crontab entries
+```
+
+### 5. Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+### Seed development data
+
+```bash
+python scripts/seed_data.py
+```
+
+## API
+
+All endpoints live under `/api/v1/`. JWT auth is required except for browse/search and public profiles.
+
+| Prefix | Description |
+|---|---|
+| `auth/` | Register, verify email, login, refresh token, password reset |
+| `users/` | Profile, ratings, GDPR export/delete |
+| `books/` | ISBN lookup, search |
+| `my-books/` | Have-list management |
+| `wishlist/` | Want-list management |
+| `matches/` | Auto-detected matches; accept/decline |
+| `proposals/` | User-initiated trade proposals |
+| `trades/` | Shipment tracking, messaging, ratings |
+| `donations/` | Institutional donation workflow |
+| `institutions/` | Library/bookstore directory |
+| `browse/` | Public book discovery, shipping estimates |
+
+## Project Structure
+
+```
+bookforbook/
+├── config/                  # Django project settings, URLs
+├── apps/
+│   ├── accounts/            # User model, auth, profiles
+│   ├── books/               # Book cache, ISBN lookup, Open Library client
+│   ├── inventory/           # Have-list (UserBook) and want-list (WishlistItem)
+│   ├── matching/            # Direct match + exchange ring detection
+│   ├── trading/             # Proposals, trades, shipment tracking
+│   ├── donations/           # Institutional donation workflow
+│   ├── ratings/             # 1-5 star ratings with rolling average
+│   ├── notifications/       # Email/in-app notifications via Django-Q2
+│   └── messaging/           # Structured trade messages
+├── frontend/                # React PWA (Vite)
+├── scripts/                 # Dev utilities (seed data)
+└── docs/                    # Architecture specification
+```
+
+## Running Tests
+
+```bash
+pytest
+```
+
+## Key Business Rules
+
+- **1-for-1 only** — every trade is exactly one book in each direction
+- **Continental USA only** — shipping addresses validated to continental US states
+- **Match capacity** — new users get 1 active match slot; grows to 10 with trading history
+- **Address privacy** — shipping addresses are encrypted at rest and revealed only to confirmed trade partners
+- **Exchange rings** — the system detects cycles of 3–5 users who can all trade with each other
+- **Inactivity** — books are auto-hidden after 3 months of inactivity and restored on next login
+
+## Docs
+
+See [`docs/bookswap-architecture.md`](docs/bookswap-architecture.md) for the full architecture specification and 8-phase build roadmap.
+
+## License
+
+MIT

--- a/SUPERUSER.md
+++ b/SUPERUSER.md
@@ -1,0 +1,400 @@
+# Superuser Guide — BookForBook
+
+This document covers everything a platform administrator needs to manage BookForBook via the Django admin panel and command line.
+
+---
+
+## Table of Contents
+
+- [Accessing the Admin Panel](#accessing-the-admin-panel)
+- [Creating a Superuser](#creating-a-superuser)
+- [Managing Users](#managing-users)
+  - [Approving Institutional Accounts](#approving-institutional-accounts)
+  - [Verifying a User's Email Manually](#verifying-a-users-email-manually)
+  - [Suspending or Deactivating a User](#suspending-or-deactivating-a-user)
+  - [Viewing a User's Books, Trades, and Ratings](#viewing-a-users-books-trades-and-ratings)
+- [Managing Books](#managing-books)
+- [Managing Matches and Trades](#managing-matches-and-trades)
+- [Managing Donations](#managing-donations)
+- [Background Tasks and Scheduling](#background-tasks-and-scheduling)
+  - [Running Periodic Tasks Manually](#running-periodic-tasks-manually)
+  - [Cron Schedule Reference](#cron-schedule-reference)
+- [Monitoring and Maintenance](#monitoring-and-maintenance)
+  - [Checking for Stuck Trades](#checking-for-stuck-trades)
+  - [Manually Expiring Old Matches](#manually-expiring-old-matches)
+  - [Triggering the Matching Engine](#triggering-the-matching-engine)
+- [Database Access](#database-access)
+- [Logs](#logs)
+- [Security Tasks](#security-tasks)
+  - [Rotating the Encryption Key](#rotating-the-encryption-key)
+  - [Rotating the Secret Key](#rotating-the-secret-key)
+- [GDPR and Data Deletion](#gdpr-and-data-deletion)
+- [Deployment Tasks](#deployment-tasks)
+  - [Applying Migrations](#applying-migrations)
+  - [Collecting Static Files](#collecting-static-files)
+  - [Restarting the Server](#restarting-the-server)
+
+---
+
+## Accessing the Admin Panel
+
+The Django admin panel is available at:
+
+```
+https://yourdomain.com/admin/
+```
+
+Log in with your superuser credentials. From here you can manage all models in the system.
+
+---
+
+## Creating a Superuser
+
+If no superuser exists yet (fresh install):
+
+```bash
+cd ~/private/bookforbook
+source .venv/bin/activate
+python manage.py createsuperuser
+```
+
+You will be prompted for a username, email, and password.
+
+To create additional admin users without full superuser privileges, create a regular user via the admin panel and grant them `Staff status` plus the specific permissions they need.
+
+---
+
+## Managing Users
+
+### Approving Institutional Accounts
+
+Libraries and bookstores must be approved by an admin before they can participate.
+
+**In the admin panel:**
+1. Go to **Accounts → Users**
+2. Filter by `account_type = library` or `account_type = bookstore`
+3. Find accounts where `is_verified = False`
+4. Open the user record
+5. Check **Is verified** and save
+
+Until `is_verified` is True, the institution will not appear in the public institutions directory and cannot receive donations.
+
+**Things to verify before approving:**
+- The institution name looks legitimate
+- The email domain matches the institution
+- They have a valid US address on file
+
+---
+
+### Verifying a User's Email Manually
+
+If a user did not receive their verification email:
+
+**In the admin panel:**
+1. Go to **Accounts → Users**
+2. Find the user
+3. Check **Email verified** and set **Email verified at** to the current time
+4. Save
+
+---
+
+### Suspending or Deactivating a User
+
+**In the admin panel:**
+1. Go to **Accounts → Users**
+2. Find the user
+3. Uncheck **Is active**
+4. Save
+
+Deactivated users cannot log in. Their books will no longer appear in matching. Any active matches they are part of should be manually cancelled (see below) or will expire naturally.
+
+To re-activate: check **Is active** again.
+
+---
+
+### Viewing a User's Books, Trades, and Ratings
+
+From a user's admin record, use the related object links at the bottom of the page to see:
+- Their have-list (UserBooks)
+- Their want-list (WishlistItems)
+- Matches they are part of (via MatchLegs)
+- Trades (via TradeShipments)
+- Ratings given and received
+
+---
+
+## Managing Books
+
+The **Books** model is a local cache of ISBN data from Open Library. You generally do not need to edit these directly.
+
+**When to edit a Book record:**
+- Open Library returned no data (title/author are blank) and you want to fill them in manually
+- A title or author was cached incorrectly
+
+**In the admin panel:** Go to **Books → Books**, search by ISBN or title, and edit the record.
+
+Books are never deleted — they are cached permanently once looked up.
+
+---
+
+## Managing Matches and Trades
+
+### Cancelling a Match
+
+If a match needs to be manually cancelled (e.g. both users report a problem):
+
+**In the admin panel:**
+1. Go to **Matching → Matches**
+2. Find the match
+3. Change `status` to `expired`
+4. Save
+
+The associated UserBooks will remain `reserved` — you may need to manually set them back to `available` via **Inventory → User books**.
+
+### Viewing All Active Trades
+
+**In the admin panel:** Go to **Trading → Trades**, filter by status `confirmed`, `shipping`, or `one_received`.
+
+### Manually Closing a Trade
+
+If both parties confirm a trade is done but the system hasn't auto-closed it:
+
+**In the admin panel:**
+1. Go to **Trading → Trades**
+2. Find the trade
+3. Set `status` to `completed` and set `completed_at` to now
+4. Save
+5. Manually mark the associated UserBooks as `traded` via **Inventory → User books**
+
+---
+
+## Managing Donations
+
+**In the admin panel:** Go to **Donations → Donations** to see all pending, accepted, and declined donations.
+
+If a donation offer is stuck (neither accepted nor declined), you can manually set its status or delete the record.
+
+---
+
+## Background Tasks and Scheduling
+
+Periodic tasks run via cron rather than a background worker (the hosting environment does not support background processes with shared memory).
+
+### Running Periodic Tasks Manually
+
+```bash
+cd ~/private/bookforbook
+source .venv/bin/activate
+
+# Run a specific task
+python manage.py run_periodic_tasks --task=matching
+python manage.py run_periodic_tasks --task=expire_matches
+python manage.py run_periodic_tasks --task=inactivity
+python manage.py run_periodic_tasks --task=rating_reminders
+python manage.py run_periodic_tasks --task=auto_close
+
+# Run all tasks at once
+python manage.py run_periodic_tasks --task=all
+```
+
+### Cron Schedule Reference
+
+Edit the crontab with `crontab -e`. Replace the paths with your actual username and paths.
+
+```
+# Every 6 hours — full matching scan
+0 */6 * * * /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=matching >> /home/bookforbook/logs/cron.log 2>&1
+
+# Every hour — expire old matches
+0 * * * * /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=expire_matches >> /home/bookforbook/logs/cron.log 2>&1
+
+# Daily at 2am — inactivity check (warnings + auto-delist)
+0 2 * * * /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=inactivity >> /home/bookforbook/logs/cron.log 2>&1
+
+# Weekly Sunday 3am — rating reminders
+0 3 * * 0 /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=rating_reminders >> /home/bookforbook/logs/cron.log 2>&1
+
+# Weekly Sunday 3:15am — auto-close expired trades
+15 3 * * 0 /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=auto_close >> /home/bookforbook/logs/cron.log 2>&1
+```
+
+Create the log directory if it doesn't exist:
+```bash
+mkdir -p ~/logs
+```
+
+View cron output:
+```bash
+tail -f ~/logs/cron.log
+```
+
+---
+
+## Monitoring and Maintenance
+
+### Checking for Stuck Trades
+
+Trades stuck in `confirmed` or `shipping` for more than 3 weeks should auto-close via cron. To check manually:
+
+**In the admin panel:** Go to **Trading → Trades**, filter by status `confirmed` or `shipping`, and sort by `confirmed_at` ascending. Any trade older than 3 weeks should have been auto-closed — if not, run the task manually:
+
+```bash
+python manage.py run_periodic_tasks --task=auto_close
+```
+
+### Manually Expiring Old Matches
+
+Matches in `pending` or `proposed` status that have passed their `expires_at` time will be cleaned up by the `expire_matches` cron task. To run immediately:
+
+```bash
+python manage.py run_periodic_tasks --task=expire_matches
+```
+
+### Triggering the Matching Engine
+
+To run the full matching scan immediately (e.g. after importing a batch of books):
+
+```bash
+python manage.py run_periodic_tasks --task=matching
+```
+
+---
+
+## Database Access
+
+Connect directly to the PostgreSQL database:
+
+```bash
+source ~/apps/postgres1/home/.bashrc
+psql bookforbook
+```
+
+Useful queries:
+
+```sql
+-- Count users by account type
+SELECT account_type, COUNT(*) FROM accounts_user GROUP BY account_type;
+
+-- All pending matches
+SELECT id, match_type, status, detected_at FROM matching_match WHERE status IN ('pending', 'proposed');
+
+-- All active trades
+SELECT id, status, confirmed_at, auto_close_at FROM trading_trade WHERE status NOT IN ('completed', 'auto_closed', 'cancelled');
+
+-- Users with books delisted due to inactivity
+SELECT username, email, books_delisted_at FROM accounts_user WHERE books_delisted_at IS NOT NULL;
+
+-- Institutions pending approval
+SELECT username, email, institution_name, account_type FROM accounts_user
+WHERE account_type IN ('library', 'bookstore') AND is_verified = false;
+```
+
+---
+
+## Logs
+
+Django logs go to stdout by default. If running via gunicorn or a process manager, redirect output to a file.
+
+To add file-based logging, add to your `.env` or `production.py`:
+
+```python
+LOGGING = {
+    'version': 1,
+    'handlers': {
+        'file': {
+            'class': 'logging.FileHandler',
+            'filename': '/home/bookforbook/logs/django.log',
+        },
+    },
+    'root': {
+        'handlers': ['file'],
+        'level': 'INFO',
+    },
+}
+```
+
+---
+
+## Security Tasks
+
+### Rotating the Encryption Key
+
+Address fields are encrypted with `FIELD_ENCRYPTION_KEY`. **Rotating this key requires re-encrypting all address data** — do not simply change it in `.env` or existing data will become unreadable.
+
+To rotate:
+1. Add the new key as a secondary key (consult `django-encrypted-model-fields` docs for multi-key rotation)
+2. Run a migration script that reads and re-saves each user record
+3. Remove the old key
+
+Contact the project maintainer before attempting this.
+
+### Rotating the Secret Key
+
+`SECRET_KEY` is used for JWT signing. Rotating it **immediately invalidates all existing JWT tokens** — all users will be logged out.
+
+To rotate:
+1. Generate a new key: `python3 -c "import secrets; print(secrets.token_urlsafe(50))"`
+2. Update `SECRET_KEY` in `.env`
+3. Restart the server
+
+---
+
+## GDPR and Data Deletion
+
+### Exporting a User's Data
+
+Users can export their own data via `GET /api/v1/users/me/export/`. As an admin you can retrieve the same data from the admin panel or via the shell:
+
+```bash
+python manage.py shell
+```
+```python
+from apps.accounts.views import _build_user_export
+from apps.accounts.models import User
+user = User.objects.get(email='user@example.com')
+import json
+print(json.dumps(_build_user_export(user), indent=2, default=str))
+```
+
+### Deleting a User's Data
+
+When a user requests deletion via the API, their account is deactivated immediately. Full anonymization (keeping rating scores but removing the user reference) should be performed after the 30-day grace period.
+
+To fully delete a user from the admin panel:
+1. Go to **Accounts → Users**
+2. Find the user
+3. Use the **Delete** action
+
+This cascades to their UserBooks, WishlistItems, and TradeProposal records. Ratings where they are the `rater` will lose the user reference (set to null or anonymized depending on your schema).
+
+---
+
+## Deployment Tasks
+
+### Applying Migrations
+
+After pulling new code:
+
+```bash
+cd ~/private/bookforbook
+source .venv/bin/activate
+git pull origin main
+pip install -r requirements.txt
+python manage.py migrate
+```
+
+### Collecting Static Files
+
+```bash
+python manage.py collectstatic --noinput
+```
+
+### Restarting the Server
+
+If running via gunicorn with a process manager, send a HUP signal to reload:
+
+```bash
+kill -HUP $(cat /tmp/gunicorn.pid)
+```
+
+Or if using a simpler setup, stop and restart the process manually.


### PR DESCRIPTION
- README.md: step-by-step usage guide for all user types (public browsers, individual traders, libraries/bookstores) with API examples, key rules, and FAQ
- SUPERUSER.md: admin guide covering user management, institutional approvals, match/trade management, cron scheduling, DB access, GDPR, and deployment
- SETUP.md: renamed from README.md — technical setup and installation docs

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq