### PR TITLE
Add WhiteNoise to serve static files through gunicorn

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -8,6 +8,9 @@ DEBUG = False
 
 ALLOWED_HOSTS = ['bookforbook.com', 'www.bookforbook.com']
 
+# WhiteNoise — serve and compress static files directly from gunicorn
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
 # Security settings
 SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ requests==2.32.3
 python-decouple==3.8
 pillow==11.0.0
 boto3==1.35.72
+whitenoise==6.8.2
 gunicorn==23.0.0
 django-filter==24.3
 pytest==8.3.3


### PR DESCRIPTION
SureSupport's reverse proxy passes all requests to gunicorn including /static/, and Django won't serve static files with DEBUG=False. WhiteNoise middleware handles this without needing web server config.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq