### PR TITLE
Fix VITE_API_URL value to include /api/v1 prefix

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -363,7 +363,9 @@ kill -HUP $(cat /tmp/bookforbook.pid)
 
    | Variable | Value |
    |----------|-------|
-   | `VITE_API_URL` | `https://api.bookforbook.com` |
+   | `VITE_API_URL` | `https://api.bookforbook.com/api/v1` |
+
+   > Note the `/api/v1` suffix — the frontend appends paths like `/browse/` directly to this value, so the full URL becomes `https://api.bookforbook.com/api/v1/browse/`.
 
 5. Click **Save and Deploy**. Cloudflare builds the app and deploys it globally in ~2 minutes.
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
-# URL of the Django API backend (no trailing slash)
+# Base URL of the Django API backend including the /api/v1 prefix (no trailing slash)
 # Development: leave blank to use the Vite proxy (proxies /api to localhost:8000)
-# Production:  set to your API domain, e.g. https://api.bookforbook.com
+# Production:  https://api.bookforbook.com/api/v1
 VITE_API_URL=


### PR DESCRIPTION
The frontend appends endpoint paths like /browse/ directly to VITE_API_URL, so the full /api/v1 prefix must be included. Without it all API calls hit /browse/ instead of /api/v1/browse/ and get a Django 404.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq