### PR TITLE
Fix browse endpoint path in api.js

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -181,7 +181,7 @@ export const institutions = {
 
 // ── Browse ────────────────────────────────────────────────────────────────────
 export const browse = {
-  available: (params) => apiClient.get('/browse/', { params }),
+  available: (params) => apiClient.get('/browse/available/', { params }),
   partnerBooks: (userId, params) => apiClient.get(`/browse/partner/${userId}/`, { params }),
   shippingEstimate: (data) => apiClient.post('/browse/shipping-estimate/', data),
 };


### PR DESCRIPTION
/browse/ does not exist — the correct URL is /browse/available/

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq