### PR TITLE
Fix registration: send password2 to API

### DIFF
--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -28,6 +28,7 @@ export default function Register() {
         email: data.email,
         username: data.username,
         password: data.password,
+        password2: data.confirmPassword,
         account_type: data.account_type,
       });
       setSuccess(true);


### PR DESCRIPTION
The RegisterSerializer requires password2 but the form was only sending password. Map confirmPassword from the form to password2 in the API call.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq