### PR TITLE
Document production settings requirement for management commands

### DIFF
--- a/SUPERUSER.md
+++ b/SUPERUSER.md
@@ -41,10 +41,31 @@ This document covers everything a platform administrator needs to manage BookFor
 The Django admin panel is available at:
 
 ```
-https://yourdomain.com/admin/
+https://api.bookforbook.com/admin/
 ```
 
 Log in with your superuser credentials. From here you can manage all models in the system.
+
+---
+
+## Important: Running Management Commands on the Server
+
+`manage.py` defaults to `config.settings.development` (which uses the console email backend and SQLite). **Always prefix management commands with the production settings module**, or add it to your shell profile.
+
+**Option A — add to `~/.bashrc` (recommended, do this once):**
+
+```bash
+echo 'export DJANGO_SETTINGS_MODULE=config.settings.production' >> ~/.bashrc
+source ~/.bashrc
+```
+
+**Option B — prefix every command:**
+
+```bash
+DJANGO_SETTINGS_MODULE=config.settings.production python manage.py <command>
+```
+
+If you forget this, emails will print to the terminal instead of being sent, and the command will connect to SQLite instead of PostgreSQL.
 
 ---
 


### PR DESCRIPTION
manage.py defaults to development settings which uses console email backend and SQLite. All server-side management commands must set DJANGO_SETTINGS_MODULE=config.settings.production or emails print to terminal instead of sending and commands hit SQLite instead of PostgreSQL.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq