### PR TITLE
Set DJANGO_SETTINGS_MODULE in gunicorn.conf.py via raw_env

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -13,3 +13,7 @@ loglevel  = "info"
 
 pidfile   = "/tmp/bookforbook.pid"   # used for graceful reloads (kill -HUP)
 proc_name = "bookforbook"
+
+raw_env = [
+    "DJANGO_SETTINGS_MODULE=config.settings.production",
+]


### PR DESCRIPTION
The SureSupport webapp environment variable was not being reliably passed to gunicorn workers, causing them to use development settings (console email backend, SQLite). Setting it in raw_env guarantees it is applied regardless of the hosting environment.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq