### PR TITLE
Fix wsgi.py to default to production settings

### DIFF
--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -8,6 +8,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.development')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'config.settings.production')
 
 application = get_wsgi_application()


### PR DESCRIPTION
manage.py and wsgi.py both defaulted to development settings. wsgi.py is what gunicorn loads, so this was causing gunicorn to use the console email backend instead of SMTP.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq