### PR TITLE
Allow psycopg2-binary>=2.9.10 for Python 3.14 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ djangorestframework==3.15.2
 djangorestframework-simplejwt==5.3.1
 django-cors-headers==4.4.0
 django-q2==1.9.0
-psycopg2-binary==2.9.9
+psycopg2-binary>=2.9.10
 cryptography==43.0.3
 django-encrypted-model-fields==0.6.5
 requests==2.32.3


### PR DESCRIPTION
2.9.9 does not have a wheel for Python 3.14; 2.9.10+ does. Railway uses Python 3.12 (runtime.txt) so this only affects local dev.

https://claude.ai/code/session_01CecHX3TzUvaUkPZfLNKTfq