### PR TITLE
security: fix issues 1-9 and 12 from security review

### DIFF
--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -216,6 +216,8 @@ class UserMeSerializer(serializers.ModelSerializer):
 class UserMeUpdateSerializer(serializers.ModelSerializer):
     """PATCH — only updatable fields."""
 
+    _ADDRESS_FIELDS = {"full_name", "address_line_1", "address_line_2", "city", "state", "zip_code"}
+
     class Meta:
         model = User
         fields = [
@@ -245,6 +247,12 @@ class UserMeUpdateSerializer(serializers.ModelSerializer):
                 "Enter a valid US ZIP code (e.g. 12345 or 12345-6789)."
             )
         return value
+
+    def update(self, instance, validated_data):
+        if self._ADDRESS_FIELDS & set(validated_data):
+            validated_data["address_verification_status"] = User.AddressVerificationStatus.UNVERIFIED
+            validated_data["address_verified_at"] = None
+        return super().update(instance, validated_data)
 
 
 class AccountDeletionSerializer(serializers.Serializer):

--- a/apps/accounts/throttles.py
+++ b/apps/accounts/throttles.py
@@ -1,4 +1,4 @@
-from rest_framework.throttling import AnonRateThrottle
+from rest_framework.throttling import AnonRateThrottle, UserRateThrottle
 
 
 class LoginRateThrottle(AnonRateThrottle):
@@ -11,3 +11,15 @@ class RegisterRateThrottle(AnonRateThrottle):
 
 class PasswordResetRateThrottle(AnonRateThrottle):
     scope = "auth_password_reset"
+
+
+class EmailVerifyRateThrottle(AnonRateThrottle):
+    scope = "auth_email_verify"
+
+
+class PasswordResetConfirmRateThrottle(AnonRateThrottle):
+    scope = "auth_reset_confirm"
+
+
+class DataExportRateThrottle(UserRateThrottle):
+    scope = "data_export"

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -27,7 +27,10 @@ from .serializers import (
     UserPublicProfileSerializer,
 )
 from .throttles import (
+    DataExportRateThrottle,
+    EmailVerifyRateThrottle,
     LoginRateThrottle,
+    PasswordResetConfirmRateThrottle,
     PasswordResetRateThrottle,
     RegisterRateThrottle,
 )
@@ -79,6 +82,7 @@ class RegisterView(APIView):
 
 class VerifyEmailView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_classes = [EmailVerifyRateThrottle]
 
     def post(self, request):
         serializer = EmailVerificationSerializer(data=request.data)
@@ -177,6 +181,7 @@ class PasswordResetRequestView(APIView):
 
 class PasswordResetConfirmView(APIView):
     permission_classes = [permissions.AllowAny]
+    throttle_classes = [PasswordResetConfirmRateThrottle]
 
     def post(self, request):
         serializer = PasswordResetConfirmSerializer(data=request.data)
@@ -184,6 +189,23 @@ class PasswordResetConfirmView(APIView):
         user = serializer.validated_data["user"]
         user.set_password(serializer.validated_data["new_password"])
         user.save(update_fields=["password"])
+
+        try:
+            from rest_framework_simplejwt.token_blacklist.models import (
+                BlacklistedToken,
+                OutstandingToken,
+            )
+
+            outstanding = OutstandingToken.objects.filter(user=user)
+            BlacklistedToken.objects.bulk_create(
+                [BlacklistedToken(token=t) for t in outstanding],
+                ignore_conflicts=True,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to blacklist tokens for user %s after password reset", user.pk
+            )
+
         return Response({"detail": "Password reset successfully."})
 
 
@@ -322,6 +344,7 @@ class UserAddressVerifyView(APIView):
 
 class UserMeExportView(APIView):
     permission_classes = [permissions.IsAuthenticated]
+    throttle_classes = [DataExportRateThrottle]
 
     def get(self, request):
         user = request.user

--- a/apps/books/serializers.py
+++ b/apps/books/serializers.py
@@ -59,7 +59,7 @@ class ImageBarcodeSerializer(serializers.Serializer):
         if value.size > self.MAX_SIZE_BYTES:
             raise serializers.ValidationError("Image must be 10 MB or smaller.")
         content_type = getattr(value, "content_type", "") or ""
-        if content_type and content_type not in self.ALLOWED_TYPES:
+        if content_type not in self.ALLOWED_TYPES:
             raise serializers.ValidationError(
                 "Unsupported image type. Upload a JPEG, PNG, WEBP, or HEIC file."
             )

--- a/apps/books/services/openlibrary.py
+++ b/apps/books/services/openlibrary.py
@@ -17,6 +17,17 @@ OPEN_LIBRARY_BOOKS_API_URL = "https://openlibrary.org/api/books"
 OPEN_LIBRARY_WORKS_URL = "https://openlibrary.org{key}.json"
 OPEN_LIBRARY_WORK_EDITIONS_URL = "https://openlibrary.org{key}/editions.json"
 
+_EDITION_KEY_RE = re.compile(r"^/books/[A-Za-z0-9]+$")
+_WORK_KEY_RE = re.compile(r"^/works/[A-Za-z0-9]+$")
+
+
+def _is_valid_edition_key(key: str) -> bool:
+    return bool(_EDITION_KEY_RE.match(str(key)))
+
+
+def _is_valid_work_key(key: str) -> bool:
+    return bool(_WORK_KEY_RE.match(str(key)))
+
 # Curated corrections for known edition edge cases where Open Library endpoints are
 # missing or return work-level mismatches for specific ISBNs.
 KNOWN_ISBN_METADATA_OVERRIDES = {
@@ -627,7 +638,7 @@ def _find_same_work_print_format(
 
     if not edition_key:
         return None
-    if not str(edition_key).startswith("/books/"):
+    if not _is_valid_edition_key(str(edition_key)):
         return None
 
     try:
@@ -646,7 +657,7 @@ def _find_same_work_print_format(
         if not works or not isinstance(works[0], dict):
             return None
         work_key = works[0].get("key")
-        if not work_key:
+        if not work_key or not _is_valid_work_key(work_key):
             return None
 
         editions_resp = requests.get(
@@ -713,7 +724,7 @@ def _find_same_work_format_for_current_isbn(
     if not edition_key and search_edition_key:
         edition_key = f"/books/{search_edition_key}"
 
-    if not edition_key or not str(edition_key).startswith("/books/"):
+    if not edition_key or not _is_valid_edition_key(str(edition_key)):
         return None
 
     try:
@@ -734,7 +745,7 @@ def _find_same_work_format_for_current_isbn(
             return None
 
         work_key = works[0].get("key")
-        if not work_key:
+        if not work_key or not _is_valid_work_key(work_key):
             return None
 
         editions_resp = requests.get(
@@ -796,9 +807,13 @@ def _fetch_edition_data(edition_key: str) -> dict:
     if normalized_key.startswith("/books/"):
         normalized_key = normalized_key.split("/books/", 1)[1]
 
+    full_key = f"/books/{normalized_key}"
+    if not _is_valid_edition_key(full_key):
+        return data
+
     try:
         resp = requests.get(
-            OPEN_LIBRARY_WORKS_URL.format(key=f"/books/{normalized_key}"),
+            OPEN_LIBRARY_WORKS_URL.format(key=full_key),
             timeout=REQUEST_TIMEOUT,
         )
         if resp.status_code == 200:

--- a/apps/trading/serializers.py
+++ b/apps/trading/serializers.py
@@ -91,31 +91,54 @@ class TradeProposalCreateSerializer(serializers.Serializer):
         return attrs
 
     def create(self, validated_data):
+        from django.db import transaction
+        from apps.inventory.models import UserBook
         from apps.trading.models import TradeProposalItem
 
         proposer = validated_data['proposer']
         recipient = validated_data['recipient']
-        proposer_book = validated_data['proposer_book']
-        recipient_book = validated_data['recipient_book']
         message = validated_data.get('message', '')
         origin_match_id = validated_data.get('origin_match_id')
 
-        proposal = TradeProposal.objects.create(
-            proposer=proposer,
-            recipient=recipient,
-            message=message,
-            origin_match_id=origin_match_id,
-        )
-        TradeProposalItem.objects.create(
-            proposal=proposal,
-            direction=TradeProposalItem.Direction.PROPOSER_SENDS,
-            user_book=proposer_book,
-        )
-        TradeProposalItem.objects.create(
-            proposal=proposal,
-            direction=TradeProposalItem.Direction.RECIPIENT_SENDS,
-            user_book=recipient_book,
-        )
+        with transaction.atomic():
+            try:
+                proposer_book = UserBook.objects.select_for_update().get(
+                    pk=validated_data['proposer_book'].pk,
+                    user=proposer,
+                    status=UserBook.Status.AVAILABLE,
+                )
+            except UserBook.DoesNotExist:
+                raise serializers.ValidationError(
+                    {'proposer_book_id': 'Book is no longer available.'}
+                )
+
+            try:
+                recipient_book = UserBook.objects.select_for_update().get(
+                    pk=validated_data['recipient_book'].pk,
+                    user=recipient,
+                    status=UserBook.Status.AVAILABLE,
+                )
+            except UserBook.DoesNotExist:
+                raise serializers.ValidationError(
+                    {'recipient_book_id': 'Book is no longer available.'}
+                )
+
+            proposal = TradeProposal.objects.create(
+                proposer=proposer,
+                recipient=recipient,
+                message=message,
+                origin_match_id=origin_match_id,
+            )
+            TradeProposalItem.objects.create(
+                proposal=proposal,
+                direction=TradeProposalItem.Direction.PROPOSER_SENDS,
+                user_book=proposer_book,
+            )
+            TradeProposalItem.objects.create(
+                proposal=proposal,
+                direction=TradeProposalItem.Direction.RECIPIENT_SENDS,
+                user_book=recipient_book,
+            )
         return proposal
 
 

--- a/apps/trading/services/trade_workflow.py
+++ b/apps/trading/services/trade_workflow.py
@@ -157,8 +157,6 @@ def reveal_addresses(trade, requesting_user) -> dict:
         Trade.Status.CONFIRMED,
         Trade.Status.SHIPPING,
         Trade.Status.ONE_RECEIVED,
-        Trade.Status.COMPLETED,
-        Trade.Status.AUTO_CLOSED,
     ]:
         return {}
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -31,6 +31,7 @@ THIRD_PARTY_APPS = [
     "django_filters",
     "dbbackup",
     "storages",
+    "csp",
 ]
 
 LOCAL_APPS = [
@@ -58,6 +59,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "csp.middleware.CSPMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"
@@ -132,6 +134,9 @@ REST_FRAMEWORK = {
         "auth_login": "10/hour",
         "auth_register": "5/hour",
         "auth_password_reset": "5/hour",
+        "auth_email_verify": "10/hour",
+        "auth_reset_confirm": "10/hour",
+        "data_export": "5/day",
     },
     "DEFAULT_FILTER_BACKENDS": [
         "django_filters.rest_framework.DjangoFilterBackend",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -77,6 +77,15 @@ SECURE_REFERRER_POLICY = "strict-origin-when-cross-origin"
 SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin"
 X_FRAME_OPTIONS = "DENY"
 
+CONTENT_SECURITY_POLICY = {
+    "DIRECTIVES": {
+        "default-src": ["'none'"],
+        "connect-src": ["'self'"],
+        "frame-ancestors": ["'none'"],
+        "form-action": ["'self'"],
+    },
+}
+
 # Railway terminates TLS at the proxy — tell Django to trust the forwarded header
 # instead of redirecting in an infinite loop
 SECURE_SSL_REDIRECT = True

--- a/frontend/src/store/authStore.js
+++ b/frontend/src/store/authStore.js
@@ -71,7 +71,9 @@ const useAuthStore = create(
       partialize: (state) => ({
         user: state.user,
         accessToken: state.accessToken,
-        refreshToken: state.refreshToken,
+        // refreshToken intentionally not persisted to localStorage —
+        // keeping it in memory only limits the XSS exfiltration window
+        // to the active session rather than the full 7-day token lifetime.
       }),
       onRehydrateStorage: () => (state) => {
         if (!state) return;

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ django-dbbackup==4.2.1
 django-storages[s3]==1.14.6
 gunicorn==23.0.0
 django-filter==24.3
+django-csp==3.8
 pytest==8.3.3
 pytest-django==4.9.0
 pytest-cov==6.0.0


### PR DESCRIPTION
## Summary

- **Issue 1**: Reset `address_verification_status` to UNVERIFIED when address fields are PATCHed
- **Issue 2** (interim): Stop persisting `refreshToken` to localStorage in Zustand store — keeps it in-memory only to limit XSS exfiltration window
- **Issue 3**: Blacklist all outstanding JWTs for a user immediately after a successful password reset
- **Issue 4**: Add rate throttles for email verify (`10/hour`) and password reset confirm (`10/hour`) endpoints
- **Issue 5**: Add `django-csp` middleware with a strict production CSP (`default-src none`, `connect-src self`, `frame-ancestors none`, `form-action self`)
- **Issue 6**: Restrict `reveal_addresses` to active shipment statuses only — no longer reveals partner addresses after a trade is completed or auto-closed
- **Issue 7**: Wrap `TradeProposalCreateSerializer.create()` in `transaction.atomic()` with `select_for_update()` re-fetch to close the proposal creation race condition
- **Issue 8**: Remove falsy short-circuit in image MIME type check so uploads with missing `content_type` are rejected
- **Issue 9**: Add rate throttle for data export endpoint (`5/day`)
- **Issue 12**: Validate OpenLibrary edition/work keys against strict regex before using them in URL construction

Issues 10 and 11 (encryption key rotation and db_e2e.sqlite3 removal) were handled separately via `git filter-repo` on main.

Issue 2 full architectural fix (moving tokens to HttpOnly cookies) is tracked as a separate GitHub issue.

## Test plan

- [ ] All 265 existing tests pass (`pytest` green)
- [ ] PATCH `/api/me/` with an address field resets `address_verification_status` to `unverified`
- [ ] Password reset clears all outstanding JWT sessions for that user
- [ ] Rapid requests to `/api/auth/verify-email/` and `/api/auth/password-reset/confirm/` are throttled after 10/hour
- [ ] Data export endpoint is throttled after 5/day per user
- [ ] CSP header is present on production responses
- [ ] Trade proposal creation under concurrent load does not double-book a book
- [ ] Image upload with no `Content-Type` header is rejected
- [ ] Malformed OpenLibrary keys (e.g. path traversal) are rejected before URL construction

https://claude.ai/code/session_01Grp4pe2QqfREwtSrFkCBGE