### PR TITLE
Add email verification resend functionality to login flow

### DIFF
--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -66,14 +66,8 @@ class LoginSerializer(serializers.Serializer):
         user = authenticate(
             request=self.context.get("request"), username=email, password=password
         )
-        if not user:
+        if not user or not user.email_verified or not user.is_active:
             raise serializers.ValidationError("Invalid email or password.")
-        if not user.email_verified:
-            raise serializers.ValidationError(
-                "Email address not verified. Please check your inbox."
-            )
-        if not user.is_active:
-            raise serializers.ValidationError("This account has been deactivated.")
         attrs["user"] = user
         return attrs
 

--- a/apps/accounts/throttles.py
+++ b/apps/accounts/throttles.py
@@ -21,5 +21,9 @@ class PasswordResetConfirmRateThrottle(AnonRateThrottle):
     scope = "auth_reset_confirm"
 
 
+class ResendVerificationRateThrottle(AnonRateThrottle):
+    scope = "auth_resend_verification"
+
+
 class DataExportRateThrottle(UserRateThrottle):
     scope = "data_export"

--- a/apps/accounts/urls.py
+++ b/apps/accounts/urls.py
@@ -8,6 +8,7 @@ urlpatterns = [
     path('token/', views.LoginView.as_view(), name='auth-login'),
     path('token/refresh/', views.TokenRefreshView.as_view(), name='auth-token-refresh'),
     path('logout/', views.LogoutView.as_view(), name='auth-logout'),
+    path('resend-verification/', views.ResendVerificationView.as_view(), name='auth-resend-verification'),
     path('password-reset/', views.PasswordResetRequestView.as_view(), name='auth-password-reset'),
     path('password-reset/confirm/', views.PasswordResetConfirmView.as_view(), name='auth-password-reset-confirm'),
 ]

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -33,6 +33,7 @@ from .throttles import (
     PasswordResetConfirmRateThrottle,
     PasswordResetRateThrottle,
     RegisterRateThrottle,
+    ResendVerificationRateThrottle,
 )
 from .tokens import email_verification_token
 
@@ -146,6 +147,30 @@ class LogoutView(APIView):
         except Exception:
             pass  # Already expired or invalid — treat as logged out
         return Response({"detail": "Logged out."}, status=status.HTTP_200_OK)
+
+
+class ResendVerificationView(APIView):
+    permission_classes = [permissions.AllowAny]
+    throttle_classes = [ResendVerificationRateThrottle]
+
+    def post(self, request):
+        email = request.data.get("email", "")
+        try:
+            user = User.objects.get(email=email, is_active=True, email_verified=False)
+            uid = urlsafe_base64_encode(force_bytes(user.pk))
+            token = email_verification_token.make_token(user)
+            from django_q.tasks import async_task
+            async_task(
+                "apps.notifications.tasks.send_verification_email",
+                str(user.pk),
+                uid,
+                token,
+            )
+        except User.DoesNotExist:
+            pass  # Don't reveal whether the email exists or is already verified
+        return Response(
+            {"detail": "If an unverified account with that email exists, a new verification link has been sent."}
+        )
 
 
 class PasswordResetRequestView(APIView):

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -136,6 +136,7 @@ REST_FRAMEWORK = {
         "auth_password_reset": "5/hour",
         "auth_email_verify": "10/hour",
         "auth_reset_confirm": "10/hour",
+        "auth_resend_verification": "5/hour",
         "data_export": "5/day",
     },
     "DEFAULT_FILTER_BACKENDS": [

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -11,6 +11,8 @@ export default function Login() {
   const location = useLocation();
   const [serverError, setServerError] = useState(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [resendEmail, setResendEmail] = useState(null);
+  const [resendStatus, setResendStatus] = useState(null);
 
   const from = location.state?.from?.pathname || '/dashboard';
 
@@ -20,8 +22,22 @@ export default function Login() {
     formState: { errors },
   } = useForm();
 
+  async function handleResend() {
+    if (!resendEmail) return;
+    setResendStatus('sending');
+    try {
+      await authApi.resendVerification({ email: resendEmail });
+    } catch {
+      // Swallow errors — the server always returns 200
+    } finally {
+      setResendStatus('sent');
+    }
+  }
+
   async function onSubmit(data) {
     setServerError(null);
+    setResendEmail(null);
+    setResendStatus(null);
     setIsSubmitting(true);
     try {
       const tokenRes = await authApi.login({
@@ -46,14 +62,15 @@ export default function Login() {
       }
       navigate(from, { replace: true });
     } catch (err) {
-      const data = err?.response?.data;
-      if (data?.detail) {
-        setServerError(data.detail);
-      } else if (data?.non_field_errors) {
-        setServerError(data.non_field_errors.join(' '));
+      const errData = err?.response?.data;
+      if (errData?.detail) {
+        setServerError(errData.detail);
+      } else if (errData?.non_field_errors) {
+        setServerError(errData.non_field_errors.join(' '));
       } else {
         setServerError('Invalid email or password. Please try again.');
       }
+      setResendEmail(data.email);
     } finally {
       setIsSubmitting(false);
     }
@@ -70,6 +87,23 @@ export default function Login() {
         {serverError && (
           <div className="alert alert-error" style={{ margin: '0 1.5rem' }}>
             {serverError}
+            {resendStatus === 'sent' ? (
+              <p style={{ marginTop: '0.5rem', fontSize: '0.875rem' }}>
+                Verification email sent — check your inbox.
+              </p>
+            ) : (
+              <p style={{ marginTop: '0.5rem', fontSize: '0.875rem' }}>
+                Can&apos;t log in?{' '}
+                <button
+                  type="button"
+                  onClick={handleResend}
+                  disabled={resendStatus === 'sending'}
+                  style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', textDecoration: 'underline', font: 'inherit', color: 'inherit' }}
+                >
+                  {resendStatus === 'sending' ? 'Sending…' : 'Resend verification email'}
+                </button>
+              </p>
+            )}
           </div>
         )}
 

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -119,6 +119,7 @@ export const auth = {
   login: (data) => apiClient.post('/auth/token/', data),
   logout: (data) => apiClient.post('/auth/logout/', data),
   verifyEmail: (data) => apiClient.post('/auth/verify-email/', data),
+  resendVerification: (data) => apiClient.post('/auth/resend-verification/', data),
   requestPasswordReset: (data) => apiClient.post('/auth/password-reset/', data),
   confirmPasswordReset: (data) => apiClient.post('/auth/password-reset/confirm/', data),
   refreshToken: (data) => apiClient.post('/auth/token/refresh/', data),


### PR DESCRIPTION
## Summary
This PR adds the ability for users to resend verification emails directly from the login page when they encounter login failures due to unverified email addresses. This improves the user experience by providing a clear path forward when email verification is the blocker.

## Key Changes

- **Frontend Login Page**: Added resend verification UI with state management for email and resend status. When a login fails, users can now click "Resend verification email" to trigger a new verification email without leaving the login page.

- **Backend ResendVerificationView**: Created new API endpoint that accepts an email address and sends a verification email if an unverified account exists. The endpoint uses generic messaging to avoid revealing whether an email is registered.

- **Rate Limiting**: Added `ResendVerificationRateThrottle` with a 5/hour limit to prevent abuse of the resend endpoint.

- **Login Validation Consolidation**: Simplified login validation to return a single generic error message for invalid credentials, unverified email, or inactive accounts. This prevents information leakage about account status.

- **API Client**: Added `resendVerification` method to the frontend auth service to call the new endpoint.

## Notable Implementation Details

- The resend endpoint returns a generic success message regardless of whether the email exists or is already verified, following security best practices to avoid account enumeration.
- The frontend tracks resend status ('sending', 'sent') to provide user feedback and prevent duplicate submissions.
- Error handling on the resend endpoint swallows exceptions since the server always returns HTTP 200, allowing the frontend to show success feedback consistently.
- The resend email button is only shown when there's a server error, and it's disabled while sending to prevent multiple submissions.

https://claude.ai/code/session_017dTQACxyXCmidt89wqUuw2