### PR TITLE
security: fix 9 findings from second audit

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import (
     BaseUserManager,
     PermissionsMixin,
 )
+from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.db import models
 from django.utils import timezone
 from encrypted_model_fields.fields import EncryptedCharField
@@ -104,7 +105,12 @@ class User(AbstractBaseUser, PermissionsMixin):
     email = models.EmailField(unique=True, db_index=True)
     email_verified = models.BooleanField(default=False)
     email_verified_at = models.DateTimeField(null=True, blank=True)
-    username = models.CharField(max_length=150, unique=True, db_index=True)
+    username = models.CharField(
+        max_length=150,
+        unique=True,
+        db_index=True,
+        validators=[UnicodeUsernameValidator()],
+    )
     account_type = models.CharField(
         max_length=20,
         choices=AccountType.choices,

--- a/apps/accounts/permissions.py
+++ b/apps/accounts/permissions.py
@@ -1,0 +1,12 @@
+from rest_framework.permissions import BasePermission
+
+
+class EmailVerifiedPermission(BasePermission):
+    message = "You must verify your email address before performing this action."
+
+    def has_permission(self, request, view):
+        return bool(
+            request.user
+            and request.user.is_authenticated
+            and request.user.email_verified
+        )

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -1,8 +1,11 @@
 from django.contrib.auth import authenticate
 from django.contrib.auth.password_validation import validate_password
+from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.utils.encoding import force_str
 from django.utils.http import urlsafe_base64_decode
 from rest_framework import serializers
+
+_username_validator = UnicodeUsernameValidator()
 
 from .disposable_email_domains import DISPOSABLE_EMAIL_DOMAINS
 from .models import CONTINENTAL_US_STATES, User
@@ -31,6 +34,15 @@ class RegisterSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 "Registration with disposable email addresses is not allowed. "
                 "Please use a permanent email address."
+            )
+        return value
+
+    def validate_username(self, value: str) -> str:
+        try:
+            _username_validator(value)
+        except Exception:
+            raise serializers.ValidationError(
+                "Username may only contain letters, digits, and @/./+/-/_ characters."
             )
         return value
 
@@ -225,6 +237,15 @@ class UserMeUpdateSerializer(serializers.ModelSerializer):
             "state",
             "zip_code",
         ]
+
+    def validate_username(self, value: str) -> str:
+        try:
+            _username_validator(value)
+        except Exception:
+            raise serializers.ValidationError(
+                "Username may only contain letters, digits, and @/./+/-/_ characters."
+            )
+        return value
 
     def validate_state(self, value):
         if value and value.upper() not in CONTINENTAL_US_STATES:

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -14,6 +14,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenRefreshView as BaseTokenRefreshView
 
 from .models import User
+from .permissions import EmailVerifiedPermission
 from .serializers import (
     AccountDeletionSerializer,
     AddressVerificationSerializer,
@@ -301,7 +302,7 @@ class UserMeView(APIView):
 
 
 class UserAddressVerifyView(APIView):
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, EmailVerifiedPermission]
 
     def post(self, request):
         serializer = AddressVerificationSerializer(data=request.data)

--- a/apps/donations/views.py
+++ b/apps/donations/views.py
@@ -6,7 +6,14 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import permissions, status
 from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
+
+
+class _DonationCreateThrottle(UserRateThrottle):
+    scope = "donation_create"
+
+from apps.accounts.permissions import EmailVerifiedPermission
 
 from .models import Donation
 from .serializers import DonationCreateSerializer, DonationSerializer
@@ -21,6 +28,11 @@ class DonationListCreateView(APIView):
     """
 
     permission_classes = [permissions.IsAuthenticated]
+
+    def get_throttles(self):
+        if self.request.method == "POST":
+            return [_DonationCreateThrottle()]
+        return super().get_throttles()
 
     def get(self, request):
         from django.db.models import Q
@@ -67,7 +79,7 @@ class DonationListCreateView(APIView):
 class DonationAcceptView(APIView):
     """POST /api/v1/donations/:id/accept/ — institution accepts a donation."""
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, EmailVerifiedPermission]
 
     def post(self, request, pk):
         with transaction.atomic():
@@ -142,11 +154,17 @@ class DonationDeclineView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, pk):
-        donation = get_object_or_404(
-            Donation, pk=pk, institution=request.user, status=Donation.Status.OFFERED
-        )
-        donation.status = Donation.Status.CANCELLED
-        donation.save(update_fields=["status"])
+        with transaction.atomic():
+            donation = (
+                Donation.objects.select_for_update()
+                .filter(pk=pk, institution=request.user, status=Donation.Status.OFFERED)
+                .first()
+            )
+            if not donation:
+                raise Http404
+
+            donation.status = Donation.Status.CANCELLED
+            donation.save(update_fields=["status"])
 
         # Notify donor
         try:

--- a/apps/inventory/serializers.py
+++ b/apps/inventory/serializers.py
@@ -106,6 +106,10 @@ class UserBookCreateSerializer(serializers.Serializer):
 
 
 class UserBookUpdateSerializer(serializers.ModelSerializer):
+    condition_notes = serializers.CharField(
+        required=False, allow_blank=True, allow_null=True, max_length=500
+    )
+
     class Meta:
         model = UserBook
         fields = ["condition", "condition_notes", "status"]

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -6,6 +6,7 @@ from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from apps.accounts.permissions import EmailVerifiedPermission
 from apps.accounts.views import user_has_verified_shipping_address
 
 from .models import Match, MatchLeg
@@ -71,7 +72,7 @@ class MatchDetailView(APIView):
 class MatchAcceptView(APIView):
     """POST /api/v1/matches/:id/accept/"""
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, EmailVerifiedPermission]
 
     def post(self, request, pk):
         user = request.user

--- a/apps/messaging/views.py
+++ b/apps/messaging/views.py
@@ -2,7 +2,12 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import permissions, status
 from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
+
+
+class _MessageCreateThrottle(UserRateThrottle):
+    scope = "message_create"
 
 from apps.trading.models import Trade
 
@@ -16,6 +21,11 @@ class TradeMessageListView(APIView):
     POST /api/v1/trades/:pk/messages/ — send a message
     """
     permission_classes = [permissions.IsAuthenticated]
+
+    def get_throttles(self):
+        if self.request.method == "POST":
+            return [_MessageCreateThrottle()]
+        return super().get_throttles()
 
     def _get_trade_and_verify_party(self, request, pk):
         trade = get_object_or_404(Trade, pk=pk)

--- a/apps/trading/serializers.py
+++ b/apps/trading/serializers.py
@@ -84,6 +84,17 @@ class TradeProposalCreateSerializer(serializers.Serializer):
                 'The recipient has reached their active match limit.'
             )
 
+        origin_match_id = attrs.get('origin_match_id')
+        if origin_match_id:
+            from apps.matching.models import Match
+            if not Match.objects.filter(
+                pk=origin_match_id,
+                legs__sender=proposer,
+            ).exists():
+                raise serializers.ValidationError(
+                    {'origin_match_id': 'Invalid or inaccessible match.'}
+                )
+
         attrs['proposer'] = proposer
         attrs['recipient'] = recipient
         attrs['proposer_book'] = proposer_book

--- a/apps/trading/tests/test_trading_api.py
+++ b/apps/trading/tests/test_trading_api.py
@@ -630,7 +630,7 @@ class TestTradeRate:
             source_id=TradeProposal.objects.create(
                 proposer=a, recipient=b, status=TradeProposal.Status.COMPLETED
             ).pk,
-            status=Trade.Status.SHIPPING,
+            status=Trade.Status.ONE_RECEIVED,
         )
         TradeShipment.objects.create(
             trade=trade, sender=a, receiver=b, user_book=book_a
@@ -688,7 +688,7 @@ class TestTradeRate:
         assert resp.status_code == 404
 
     def test_rate_confirmed_trade_rejected(self, api_client):
-        """Trade must be in shipping/received/completed/auto_closed to rate."""
+        """Trade must be in one_received/completed/auto_closed to rate."""
         trade, a, b = self._setup_shipping_trade()
         trade.status = Trade.Status.CONFIRMED
         trade.save()
@@ -1080,7 +1080,7 @@ class TestTradeRateViewEdgeCases:
             source_id=TradeProposal.objects.create(
                 proposer=a, recipient=b, status=TradeProposal.Status.COMPLETED
             ).pk,
-            status=Trade.Status.SHIPPING,
+            status=Trade.Status.ONE_RECEIVED,
         )
         TradeShipment.objects.create(
             trade=trade, sender=a, receiver=b, user_book=book_a

--- a/apps/trading/tests/test_trading_api.py
+++ b/apps/trading/tests/test_trading_api.py
@@ -1066,7 +1066,7 @@ class TestTradeRateViewEdgeCases:
     """Lines 417-418, 428, 460-461, 479-481 of TradeRateView."""
 
     def _setup_ratable_trade(self):
-        """Create a SHIPPING trade with two parties."""
+        """Create a ONE_RECEIVED trade with two parties."""
         a = UserFactory()
         b = UserFactory()
         book_a = UserBookFactory(
@@ -1184,7 +1184,7 @@ class TestTradeRateViewEdgeCases:
 
         trade.refresh_from_db()
         # Only one rating so far — not yet completed
-        assert trade.status == Trade.Status.SHIPPING
+        assert trade.status == Trade.Status.ONE_RECEIVED
 
         # User b rates user a
         client_b = _auth(api_client, b)

--- a/apps/trading/views.py
+++ b/apps/trading/views.py
@@ -5,8 +5,14 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import permissions, status
 from rest_framework.response import Response
+from rest_framework.throttling import UserRateThrottle
 from rest_framework.views import APIView
 
+
+class _ProposalCreateThrottle(UserRateThrottle):
+    scope = "proposal_create"
+
+from apps.accounts.permissions import EmailVerifiedPermission
 from apps.accounts.views import user_has_verified_shipping_address
 
 from .models import Trade, TradeProposal, TradeShipment
@@ -28,6 +34,11 @@ class ProposalListCreateView(APIView):
     """
 
     permission_classes = [permissions.IsAuthenticated]
+
+    def get_throttles(self):
+        if self.request.method == "POST":
+            return [_ProposalCreateThrottle()]
+        return super().get_throttles()
 
     def get(self, request):
         from django.db.models import Q
@@ -90,7 +101,7 @@ class ProposalDetailView(APIView):
 class ProposalAcceptView(APIView):
     """POST /api/v1/proposals/:id/accept/"""
 
-    permission_classes = [permissions.IsAuthenticated]
+    permission_classes = [permissions.IsAuthenticated, EmailVerifiedPermission]
 
     def post(self, request, pk):
         proposal = get_object_or_404(
@@ -275,24 +286,28 @@ class TradeMarkShippedView(APIView):
         if not is_party:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
 
-        # Find the sender's shipment
-        try:
-            shipment = trade.shipments.get(
-                sender=request.user, status=TradeShipment.Status.PENDING
-            )
-        except TradeShipment.DoesNotExist:
-            return Response(
-                {"detail": "No pending shipment found for you in this trade."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
         from apps.trading.services.trade_workflow import mark_shipped
 
-        mark_shipped(
-            shipment,
-            tracking=serializer.validated_data.get("tracking_number", ""),
-            method=serializer.validated_data.get("shipping_method", ""),
-        )
+        with transaction.atomic():
+            try:
+                shipment = TradeShipment.objects.select_for_update().get(
+                    trade=trade,
+                    sender=request.user,
+                    status=TradeShipment.Status.PENDING,
+                )
+            except TradeShipment.DoesNotExist:
+                return Response(
+                    {"detail": "No pending shipment found for you in this trade."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+
+            mark_shipped(
+                shipment,
+                tracking=serializer.validated_data.get("tracking_number", ""),
+                method=serializer.validated_data.get("shipping_method", ""),
+            )
+
+        trade.refresh_from_db()
         return Response(TradeSerializer(trade, context={"request": request}).data)
 
 
@@ -347,9 +362,9 @@ class TradeRateView(APIView):
         if not is_party:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
 
-        # Trade must be at a ratable status
+        # Trade must be at a ratable status — SHIPPING is excluded so neither
+        # party can rate before at least one book has been confirmed received.
         if trade.status not in [
-            Trade.Status.SHIPPING,
             Trade.Status.ONE_RECEIVED,
             Trade.Status.COMPLETED,
             Trade.Status.AUTO_CLOSED,

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -11,6 +11,10 @@ BASE_DIR = Path(__file__).resolve().parent.parent.parent
 SECRET_KEY = config("SECRET_KEY", default="django-insecure-change-me-in-production")
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", default="localhost,127.0.0.1", cast=Csv())
 
+# Dedicated JWT signing key — defaults to SECRET_KEY if not explicitly set.
+# In production this must be a separate value (enforced in production.py).
+JWT_SIGNING_KEY = config("JWT_SIGNING_KEY", default=SECRET_KEY)
+
 # Application definition
 DJANGO_APPS = [
     "django.contrib.admin",
@@ -138,6 +142,9 @@ REST_FRAMEWORK = {
         "auth_reset_confirm": "10/hour",
         "auth_resend_verification": "5/hour",
         "data_export": "5/day",
+        "proposal_create": "30/hour",
+        "donation_create": "30/hour",
+        "message_create": "120/hour",
     },
     "DEFAULT_FILTER_BACKENDS": [
         "django_filters.rest_framework.DjangoFilterBackend",
@@ -157,7 +164,7 @@ SIMPLE_JWT = {
     "BLACKLIST_AFTER_ROTATION": True,
     "UPDATE_LAST_LOGIN": False,
     "ALGORITHM": "HS256",
-    "SIGNING_KEY": SECRET_KEY,
+    "SIGNING_KEY": JWT_SIGNING_KEY,
     "AUTH_HEADER_TYPES": ("Bearer",),
     "AUTH_HEADER_NAME": "HTTP_AUTHORIZATION",
     "USER_ID_FIELD": "id",

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -14,6 +14,11 @@ _INSECURE_DEFAULT_FIELD_ENCRYPTION_KEY = "NmzoBw3C4Rvblhs8AsAsnF-GYGVQatPZnEuvj_
 if SECRET_KEY == _INSECURE_DEFAULT_SECRET_KEY:  # noqa: F405
     raise ImproperlyConfigured("SECRET_KEY must be set via environment in production.")
 
+if JWT_SIGNING_KEY == SECRET_KEY:  # noqa: F405
+    raise ImproperlyConfigured(
+        "JWT_SIGNING_KEY must be set to a value distinct from SECRET_KEY in production."
+    )
+
 
 # Fail if FIELD_ENCRYPTION_KEY is unset or set to any known insecure value
 _INSECURE_FIELD_ENCRYPTION_KEYS = [


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Security fixes from the second automated audit pass. All 9 findings addressed in a single commit.

- **Finding 1 — Email verification gate (High):** New `EmailVerifiedPermission` class applied to `UserAddressVerifyView`, `ProposalAcceptView`, `DonationAcceptView`, and `MatchAcceptView`. Unverified-email accounts can no longer complete USPS address verification or accept trades/donations.

- **Finding 2 — Username injection (Medium):** Added `UnicodeUsernameValidator` to the `User.username` model field and `validate_username` to both `RegisterSerializer` and `UserMeUpdateSerializer`. Blocks characters like `<`, `>`, `"` that would propagate into notification body strings sent to other users.

- **Finding 3 — JWT key shares SECRET_KEY (Medium):** Introduced a dedicated `JWT_SIGNING_KEY` config var (defaults to `SECRET_KEY` in dev). Production now enforces it must be set to a distinct value, decoupling JWT forgery risk from Django's session/CSRF/password-reset HMAC operations. **Action required:** add `JWT_SIGNING_KEY` to Railway env vars before next production deploy.

- **Finding 4 — No rate limits on create endpoints (Medium):** Added `proposal_create` (30/hr), `donation_create` (30/hr), and `message_create` (120/hr) throttles applied to POST only via `get_throttles()` overrides — GET requests are unaffected.

- **Finding 5 — Unbounded condition_notes on PATCH (Low):** Explicit `max_length=500` field override in `UserBookUpdateSerializer` to match the create serializer.

- **Finding 6 — origin_match_id not ownership-validated (Low):** `TradeProposalCreateSerializer` now verifies the proposer is a sender leg in the referenced match before accepting the field.

- **Finding 7 — DonationDeclineView race condition (Low):** Wrapped status update in `transaction.atomic()` + `select_for_update()`, mirroring the existing pattern in `DonationAcceptView`.

- **Finding 8 — TradeMarkShippedView race condition (Low):** Wrapped shipment fetch and `mark_shipped()` call in `transaction.atomic()` + `select_for_update()` to prevent duplicate shipment notifications.

- **Finding 9 — Premature trade ratings (Low):** Removed `Trade.Status.SHIPPING` from the ratable statuses list. Ratings now require at least one delivery confirmation (`ONE_RECEIVED`, `COMPLETED`, or `AUTO_CLOSED`).

## Test plan

- [ ] Register a new user — attempt USPS address verification before verifying email → expect 403
- [ ] Verify email → retry address verification → succeeds
- [ ] Try registering with username `<script>alert(1)</script>` → expect 400
- [ ] Try registering with username `valid_user.123` → succeeds
- [ ] Confirm `JWT_SIGNING_KEY` is set in Railway before deploying (new required env var)
- [ ] POST >30 proposals in an hour from one account → expect 429 on the 31st
- [ ] PATCH a book with `condition_notes` longer than 500 chars → expect 400
- [ ] Attempt to submit a rating on a trade in SHIPPING status → expect 400
- [ ] Concurrent decline requests on a donation → only one notification sent to donor

https://claude.ai/code/session_017dTQACxyXCmidt89wqUuw2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_017dTQACxyXCmidt89wqUuw2)_