### PR TITLE
Clarify institutional account participation rules

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -176,7 +176,7 @@ browse/         available/, available/?q=, partner/:id/books/, shipping-estimate
 
 10. **Ring size limit**: Exchange rings are limited to 5 participants for logistics manageability.
 
-11. **Institutional accounts**: Libraries and bookstores only receive donations — they do NOT trade. They require admin approval via Django admin before they can participate.
+11. **Institutional accounts**: Libraries and bookstores require admin approval via Django admin before they can participate. They are excluded from automated match detection but can list books on their have-list and participate in manual trade proposals. They also receive donations from individuals.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ Your data export is emailed to you. Active matches and proposals are cancelled. 
 
 ## For Libraries and Bookstores
 
-Libraries and bookstores participate differently from individual traders — they **receive donations only**. They do not trade or ship books out.
+Libraries and bookstores participate differently from individual traders — they are excluded from automated match detection. However, they can list books on their have-list and participate in manual trade proposals. They can also receive donations from individuals.
 
 ### Getting Approved
 
@@ -478,7 +478,7 @@ Once accepted, the donor ships the book to your institution. No address reveal i
 | Auto-close | Trades auto-close 3 weeks after confirmation if no ratings are submitted |
 | Inactivity | Books hidden after 3 months inactive; restored on next login |
 | No disputes | The rating system is the sole accountability mechanism. There is no dispute resolution. |
-| Institutional accounts | Libraries and bookstores require admin approval and can only receive donations |
+| Institutional accounts | Libraries and bookstores require admin approval; excluded from auto-matching but can list books and send/receive manual proposals |
 
 ---
 


### PR DESCRIPTION
## Summary
Updated documentation to accurately reflect how libraries and bookstores participate in the platform. The previous description was overly restrictive and didn't capture the full scope of their capabilities.

## Changes Made
- **README.md**: Clarified that institutional accounts are excluded from automated match detection but can actively participate through manual trade proposals and donations
- **ARCHITECTURE.md**: Expanded the institutional accounts constraint description to explain that while they're excluded from auto-matching, they retain the ability to list books and engage in manual trading

## Details
The original documentation stated that libraries and bookstores "receive donations only" and "do not trade," which was inaccurate. The updated text clarifies that:
- They are excluded from the automated matching system (not from trading entirely)
- They can list books on their have-list
- They can send and receive manual trade proposals
- They can receive donations from individuals
- They still require admin approval before participation

This change ensures the documentation accurately reflects the platform's actual functionality for institutional accounts.

https://claude.ai/code/session_01AQ9UXCmxMoGgeKXDKwtVVC