### PR TITLE
Fetch book descriptions from Open Library work records

### DIFF
--- a/apps/books/services/openlibrary.py
+++ b/apps/books/services/openlibrary.py
@@ -18,7 +18,7 @@ OPEN_LIBRARY_WORKS_URL = "https://openlibrary.org{key}.json"
 OPEN_LIBRARY_WORK_EDITIONS_URL = "https://openlibrary.org{key}/editions.json"
 
 _EDITION_KEY_RE = re.compile(r"^/books/[A-Za-z0-9]+$")
-_WORK_KEY_RE = re.compile(r"^/works/[A-Za-z0-9]+$")
+_WORK_KEY_RE = re.compile(r"^/works/OL\d+W$")
 _AUTHOR_KEY_RE = re.compile(r"^/authors/OL\d+A$")
 
 
@@ -489,10 +489,17 @@ def _parse_isbn_response_collect_keys(
     elif isinstance(desc, str):
         data["description"] = desc
 
-    works = raw.get("works", [])
-    if works and isinstance(works[0], dict):
-        work_key = works[0].get("key")
-        if work_key and _is_valid_work_key(work_key):
+    works = raw.get("works")
+    if isinstance(works, list):
+        work_key = next(
+            (
+                entry.get("key")
+                for entry in works
+                if isinstance(entry, dict) and _is_valid_work_key(entry.get("key", ""))
+            ),
+            None,
+        )
+        if work_key:
             data["work_key"] = work_key
 
     return data

--- a/apps/books/services/openlibrary.py
+++ b/apps/books/services/openlibrary.py
@@ -354,6 +354,12 @@ def fetch_from_open_library(isbn_13: str) -> dict:
         if preferred_print_format:
             data["physical_format"] = preferred_print_format
 
+    # Descriptions live at the work level, not the edition level — fetch if still missing.
+    if not data.get("description"):
+        work_key = data.get("work_key") or search_data.get("work_key")
+        if work_key:
+            data = _merge_book_data(data, _fetch_work_data(work_key))
+
     # Always ensure cover URL
     if not data.get("cover_image_url"):
         data["cover_image_url"] = OPEN_LIBRARY_COVER_URL.format(isbn=isbn_13)
@@ -483,6 +489,12 @@ def _parse_isbn_response_collect_keys(
     elif isinstance(desc, str):
         data["description"] = desc
 
+    works = raw.get("works", [])
+    if works and isinstance(works[0], dict):
+        work_key = works[0].get("key")
+        if work_key and _is_valid_work_key(work_key):
+            data["work_key"] = work_key
+
     return data
 
 
@@ -514,6 +526,9 @@ def _parse_search_result(doc: dict, isbn_13: str) -> dict:
     data["edition_key"] = doc.get("cover_edition_key") or (
         doc.get("edition_key", [None])[0] if doc.get("edition_key") else None
     )
+    work_key = doc.get("key")
+    if work_key and _is_valid_work_key(work_key):
+        data["work_key"] = work_key
     subjects = doc.get("subject", [])
     data["subjects"] = subjects[:20] if subjects else []
     cover_id = doc.get("cover_i")
@@ -843,6 +858,38 @@ def _fetch_edition_data(edition_key: str) -> dict:
     except requests.RequestException as e:
         logger.debug("Edition data fetch failed for %s: %s", normalized_key, e)
     return data
+
+
+def _fetch_work_data(work_key: str) -> dict:
+    """Fetch description and subjects from an Open Library work record."""
+    if not _is_valid_work_key(work_key):
+        return {}
+    try:
+        resp = requests.get(
+            OPEN_LIBRARY_WORKS_URL.format(key=work_key),
+            timeout=REQUEST_TIMEOUT,
+        )
+        if resp.status_code != 200:
+            return {}
+        raw = _response_json_object(resp, f"work lookup for {work_key}")
+        if not raw:
+            return {}
+
+        data: dict = {}
+        desc = raw.get("description")
+        if isinstance(desc, dict):
+            data["description"] = desc.get("value", "")
+        elif isinstance(desc, str):
+            data["description"] = desc
+
+        subjects = raw.get("subjects", [])
+        if subjects:
+            data["subjects"] = subjects[:20]
+
+        return data
+    except requests.RequestException as e:
+        logger.debug("Work data fetch failed for %s: %s", work_key, e)
+        return {}
 
 
 def _fetch_author_name(author_key: str) -> str | None:

--- a/apps/books/tests/test_openlibrary.py
+++ b/apps/books/tests/test_openlibrary.py
@@ -12,6 +12,7 @@ from apps.books.services.openlibrary import (
     isbn10_to_isbn13,
     isbn13_to_isbn10,
     normalize_isbn,
+    _fetch_work_data,
     _normalize_physical_format,
     _parse_isbn_response_collect_keys,
     _parse_search_result,
@@ -682,6 +683,164 @@ def test_fetch_from_open_library_handles_edition_404():
 
     assert data.get("physical_format") is None
     assert "cover_image_url" in data
+
+
+# ---------------------------------------------------------------------------
+# _fetch_work_data
+# ---------------------------------------------------------------------------
+
+
+class TestFetchWorkData:
+    def _make_resp(self, status_code, payload):
+        from unittest.mock import MagicMock
+        r = MagicMock()
+        r.status_code = status_code
+        r.json.return_value = payload
+        return r
+
+    def test_extracts_description_string(self):
+        resp = self._make_resp(200, {"description": "A great book about things."})
+        with patch("apps.books.services.openlibrary.requests.get", return_value=resp):
+            data = _fetch_work_data("/works/OL123W")
+        assert data["description"] == "A great book about things."
+
+    def test_extracts_description_dict_value(self):
+        resp = self._make_resp(200, {
+            "description": {"type": "/type/text", "value": "A dict-wrapped synopsis."}
+        })
+        with patch("apps.books.services.openlibrary.requests.get", return_value=resp):
+            data = _fetch_work_data("/works/OL123W")
+        assert data["description"] == "A dict-wrapped synopsis."
+
+    def test_extracts_subjects(self):
+        subjects = ["Fiction", "Mystery", "Thriller"]
+        resp = self._make_resp(200, {"subjects": subjects})
+        with patch("apps.books.services.openlibrary.requests.get", return_value=resp):
+            data = _fetch_work_data("/works/OL123W")
+        assert data["subjects"] == subjects
+
+    def test_returns_empty_on_404(self):
+        resp = self._make_resp(404, {})
+        with patch("apps.books.services.openlibrary.requests.get", return_value=resp):
+            data = _fetch_work_data("/works/OL123W")
+        assert data == {}
+
+    def test_returns_empty_on_invalid_work_key(self):
+        data = _fetch_work_data("/books/OL123M")
+        assert data == {}
+
+    def test_returns_empty_on_request_exception(self):
+        import requests
+        with patch(
+            "apps.books.services.openlibrary.requests.get",
+            side_effect=requests.ConnectionError("no network"),
+        ):
+            data = _fetch_work_data("/works/OL123W")
+        assert data == {}
+
+
+def test_fetch_from_open_library_populates_description_from_work_endpoint():
+    """Description must be fetched from the work record when absent from edition/search."""
+
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    def mock_get(url, **kwargs):
+        if "isbn/9780201616224.json" in url:
+            return FakeResponse(200, {
+                "title": "The Pragmatic Programmer",
+                "authors": [{"name": "David Thomas"}],
+                "works": [{"key": "/works/OL123W"}],
+            })
+        if "search.json" in url:
+            return FakeResponse(200, {"docs": []})
+        if "/works/OL123W.json" in url:
+            return FakeResponse(200, {
+                "description": "A seminal guide to software craftsmanship.",
+            })
+        return FakeResponse(404, {})
+
+    with patch("apps.books.services.openlibrary.requests.get", side_effect=mock_get):
+        data = fetch_from_open_library("9780201616224")
+
+    assert data["description"] == "A seminal guide to software craftsmanship."
+
+
+def test_fetch_from_open_library_uses_search_work_key_for_description():
+    """work_key from search result is used as fallback when ISBN endpoint has no works."""
+
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    def mock_get(url, **kwargs):
+        if "isbn/9780201616224.json" in url:
+            return FakeResponse(200, {
+                "title": "The Pragmatic Programmer",
+                "authors": [{"name": "David Thomas"}],
+            })
+        if "search.json" in url:
+            return FakeResponse(200, {
+                "docs": [{
+                    "title": "The Pragmatic Programmer",
+                    "author_name": ["David Thomas"],
+                    "key": "/works/OL456W",
+                }]
+            })
+        if "/works/OL456W.json" in url:
+            return FakeResponse(200, {
+                "description": {"type": "/type/text", "value": "From search work key."},
+            })
+        return FakeResponse(404, {})
+
+    with patch("apps.books.services.openlibrary.requests.get", side_effect=mock_get):
+        data = fetch_from_open_library("9780201616224")
+
+    assert data["description"] == "From search work key."
+
+
+def test_fetch_from_open_library_skips_work_fetch_when_description_already_present():
+    """_fetch_work_data must not be called when description is already populated."""
+
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    work_fetched = []
+
+    def mock_get(url, **kwargs):
+        if "isbn/9780201616224.json" in url:
+            return FakeResponse(200, {
+                "title": "The Pragmatic Programmer",
+                "authors": [{"name": "David Thomas"}],
+                "description": "Already here.",
+                "works": [{"key": "/works/OL123W"}],
+            })
+        if "search.json" in url:
+            return FakeResponse(200, {"docs": []})
+        if "/works/OL123W.json" in url:
+            work_fetched.append(url)
+            return FakeResponse(200, {"description": "Should not overwrite."})
+        return FakeResponse(404, {})
+
+    with patch("apps.books.services.openlibrary.requests.get", side_effect=mock_get):
+        data = fetch_from_open_library("9780201616224")
+
+    assert data["description"] == "Already here."
+    assert work_fetched == []
 
 
 def test_fetch_author_name_returns_none_on_non_200():


### PR DESCRIPTION
## Summary
Enhanced the Open Library book fetching logic to retrieve book descriptions from work-level records when they're not available at the edition level. This ensures more complete book metadata by leveraging Open Library's hierarchical data structure where descriptions are typically stored at the work level rather than the edition level.

## Key Changes
- **New `_fetch_work_data()` function**: Fetches description and subjects from Open Library work records via the `/works/{key}.json` endpoint, with proper error handling for invalid keys, non-200 responses, and network failures
- **Work key extraction**: Updated `_parse_isbn_response_collect_keys()` and `_parse_search_result()` to extract and validate work keys from ISBN and search responses
- **Fallback description logic**: Modified `fetch_from_open_library()` to fetch work data when description is missing, using work keys from either the ISBN endpoint or search results
- **Optimization**: Added check to skip work data fetching when description is already present in the edition/ISBN response
- **Comprehensive test coverage**: Added 6 new tests covering work data extraction, error handling, and integration scenarios

## Implementation Details
- Work key validation uses existing `_is_valid_work_key()` helper to ensure only valid `/works/OL*W` keys are processed
- Description extraction handles both string and dict formats (with `value` field) from Open Library API responses
- Subjects are limited to 20 items (consistent with existing behavior)
- Network errors and invalid responses gracefully return empty dict without raising exceptions
- Uses `_merge_book_data()` to combine work-level data with existing edition data

https://claude.ai/code/session_01TCGAYryoCgRVhom5TJqNLm