### PR TITLE
fix: populate book descriptions, covers from Open Library work endpoint

### DIFF
--- a/apps/books/management/commands/refresh_books.py
+++ b/apps/books/management/commands/refresh_books.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--missing-only",
             action="store_true",
-            help="Only refresh books that are missing authors or physical_format",
+            help="Only refresh books that are missing authors, physical_format, or description",
         )
         parser.add_argument(
             "--dry-run",
@@ -130,7 +130,11 @@ class Command(BaseCommand):
         qs = Book.objects.all().order_by("created_at")
         if missing_only:
             qs = qs.filter(
-                Q(authors=[]) | Q(authors__isnull=True) | Q(physical_format__isnull=True)
+                Q(authors=[])
+                | Q(authors__isnull=True)
+                | Q(physical_format__isnull=True)
+                | Q(description__isnull=True)
+                | Q(description="")
             )
         return qs
 

--- a/apps/books/services/openlibrary.py
+++ b/apps/books/services/openlibrary.py
@@ -480,6 +480,12 @@ def _parse_isbn_response_collect_keys(
         year_match = re.search(r"\d{4}", publish_date)
         data["publish_year"] = int(year_match.group()) if year_match else None
 
+    covers = raw.get("covers")
+    if isinstance(covers, list) and covers:
+        data["cover_image_url"] = (
+            f"https://covers.openlibrary.org/b/id/{covers[0]}-M.jpg"
+        )
+
     subjects = raw.get("subjects", [])
     data["subjects"] = subjects[:20] if subjects else []
 
@@ -850,6 +856,19 @@ def _fetch_edition_data(edition_key: str) -> dict:
                     data["cover_image_url"] = (
                         f"https://covers.openlibrary.org/b/id/{covers[0]}-M.jpg"
                     )
+                works = raw.get("works")
+                if isinstance(works, list):
+                    edition_work_key = next(
+                        (
+                            entry.get("key")
+                            for entry in works
+                            if isinstance(entry, dict)
+                            and _is_valid_work_key(entry.get("key", ""))
+                        ),
+                        None,
+                    )
+                    if edition_work_key:
+                        data["work_key"] = edition_work_key
                 author_keys = []
                 inline_authors = []
                 for author_ref in raw.get("authors", []):

--- a/apps/books/services/openlibrary.py
+++ b/apps/books/services/openlibrary.py
@@ -138,7 +138,7 @@ def _book_needs_enrichment(book) -> bool:
     """Return True when cached book metadata is incomplete enough to re-fetch."""
     if _is_placeholder_title(book.title):
         return True
-    return not book.authors or not book.physical_format
+    return not book.authors or not book.physical_format or not book.description
 
 
 def _update_book_from_data(book, data: dict) -> None:

--- a/apps/books/tests/test_openlibrary.py
+++ b/apps/books/tests/test_openlibrary.py
@@ -424,6 +424,7 @@ def test_get_or_create_book_does_not_refetch_cached_audio_edition():
         title="Billion Dollar Whale",
         authors=["Bradley Hope", "Tom Wright"],
         physical_format="Audio CD",
+        description="The story of a massive financial fraud.",
     )
 
     with patch(
@@ -568,6 +569,7 @@ def test_get_or_create_book_skips_enrichment_when_complete():
         isbn_13="9780201616224",
         authors=["Author One"],
         physical_format="Paperback",
+        description="A complete book with all metadata.",
     )
 
     with patch("apps.books.services.openlibrary.fetch_from_open_library") as mock_fetch:

--- a/apps/books/tests/test_openlibrary.py
+++ b/apps/books/tests/test_openlibrary.py
@@ -96,6 +96,16 @@ class TestOpenLibraryFormatParsing:
         assert parsed["physical_format"] == "Mass Market Paperback"
         assert author_keys == []
 
+    def test_parse_isbn_response_extracts_cover_from_covers_field(self):
+        raw = {
+            "title": "Example",
+            "authors": [],
+            "covers": [12345678],
+        }
+        author_keys: list = []
+        parsed = _parse_isbn_response_collect_keys(raw, "9780201616224", author_keys)
+        assert parsed["cover_image_url"] == "https://covers.openlibrary.org/b/id/12345678-M.jpg"
+
     def test_parse_search_result_extracts_physical_format(self):
         doc = {
             "title": "Example",
@@ -843,6 +853,79 @@ def test_fetch_from_open_library_skips_work_fetch_when_description_already_prese
 
     assert data["description"] == "Already here."
     assert work_fetched == []
+
+
+def test_fetch_from_open_library_gets_cover_and_description_via_edition_work_key():
+    """When ISBN endpoint has covers[] and its edition record has a works[] key,
+    both cover and description should be populated even without a search work key."""
+
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    def mock_get(url, **kwargs):
+        if "isbn/9780143136439.json" in url:
+            return FakeResponse(200, {
+                "title": "The Book",
+                "authors": [{"name": "Some Author"}],
+                "covers": [99887766],
+                "works": [{"key": "/works/OL99887W"}],
+            })
+        if "search.json" in url:
+            return FakeResponse(200, {"docs": []})
+        if "/works/OL99887W.json" in url:
+            return FakeResponse(200, {"description": "A synopsis from the work record."})
+        return FakeResponse(404, {})
+
+    with patch("apps.books.services.openlibrary.requests.get", side_effect=mock_get):
+        data = fetch_from_open_library("9780143136439")
+
+    assert data["cover_image_url"] == "https://covers.openlibrary.org/b/id/99887766-M.jpg"
+    assert data["description"] == "A synopsis from the work record."
+
+
+def test_fetch_from_open_library_gets_description_via_edition_data_work_key():
+    """work_key extracted from edition-data fetch (covers/format fallback path)
+    must be used to populate description when ISBN and search don't provide one."""
+
+    class FakeResponse:
+        def __init__(self, status_code, payload):
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self):
+            return self._payload
+
+    def mock_get(url, **kwargs):
+        if "isbn/9780143136439.json" in url:
+            # No covers, no works — cover and work_key must come from edition fetch
+            return FakeResponse(200, {
+                "title": "The Book",
+                "authors": [{"name": "Some Author"}],
+            })
+        if "search.json" in url:
+            return FakeResponse(200, {
+                "docs": [{"title": "The Book", "cover_edition_key": "OL55443M"}]
+            })
+        if "/books/OL55443M.json" in url:
+            return FakeResponse(200, {
+                "physical_format": "Paperback",
+                "covers": [55443322],
+                "works": [{"key": "/works/OL55443W"}],
+            })
+        if "/works/OL55443W.json" in url:
+            return FakeResponse(200, {"description": "Description via edition work key."})
+        return FakeResponse(404, {})
+
+    with patch("apps.books.services.openlibrary.requests.get", side_effect=mock_get):
+        data = fetch_from_open_library("9780143136439")
+
+    assert data["cover_image_url"] == "https://covers.openlibrary.org/b/id/55443322-M.jpg"
+    assert data["description"] == "Description via edition work key."
 
 
 def test_fetch_author_name_returns_none_on_non_200():


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause — descriptions always empty**: Open Library stores descriptions at the *work* level (`/works/OL123W.json`), not the edition level. The ISBN and search endpoints almost never carry a description, so the field was always null.
- **Root cause — covers missing for some ISBNs**: The ISBN endpoint response includes a `covers[]` array of cover IDs that was being ignored. Cover was only sourced from the search result or a separate edition fetch, leaving books with only the fallback ISBN-based URL (which returns a placeholder for many editions).
- **Backfill also broken**: `_book_needs_enrichment` and `refresh_books --missing-only` both only checked `authors`/`physical_format`, so existing books with those fields populated were never re-fetched or targeted by the management command.

## Changes

- Add `_fetch_work_data()` to fetch description and subjects from `/works/OL{id}W.json`
- Extract `work_key` from three sources: ISBN endpoint `works[]`, search result `key`, and edition-data `works[]` (fallback)
- Call `_fetch_work_data` in `fetch_from_open_library` when description is still missing after all other sources
- Extract `covers[]` from the ISBN endpoint response in `_parse_isbn_response_collect_keys`
- Add `not book.description` to `_book_needs_enrichment` so cached books without a description are re-fetched on next lookup
- Extend `refresh_books --missing-only` filter to include books with null/empty description
- Tighten `_WORK_KEY_RE` from `[A-Za-z0-9]+` to `OL\d+W` to match the actual Open Library format
- Harden `works[0]` indexing with `isinstance` guard + `next()` scan

## Test plan

- [ ] Add a new book by ISBN — cover image and synopsis should populate in the popup
- [ ] Run `python manage.py refresh_books --missing-only` — should target and backfill existing books missing description
- [ ] Run `python manage.py refresh_books --missing-only --dry-run` first to preview what would change
- [ ] All 54 unit tests pass (`pytest apps/books/tests/test_openlibrary.py -m "not integration and not slow"`)

https://claude.ai/code/session_01TCGAYryoCgRVhom5TJqNLm
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCGAYryoCgRVhom5TJqNLm)_