### PR TITLE
Add status filtering to match list endpoint

### DIFF
--- a/apps/matching/tests/test_match_views.py
+++ b/apps/matching/tests/test_match_views.py
@@ -49,13 +49,18 @@ class TestMatchViews:
         assert str(pending_match.id) not in returned_ids
 
     def test_match_list_status_filter_pending_excludes_completed(self, api_client):
-        """Completed matches must not appear under status=pending."""
+        """Completed matches and matches where the user already accepted must not appear under status=pending."""
         user = UserFactory()
         other = UserFactory()
         api_client.force_authenticate(user=user)
 
         pending_match = MatchFactory(status=Match.Status.PENDING)
         MatchLegFactory(match=pending_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
+
+        # User already accepted their sender leg; match is still PENDING waiting for the other party.
+        already_accepted_match = MatchFactory(status=Match.Status.PENDING)
+        MatchLegFactory(match=already_accepted_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(match=already_accepted_match, sender=other, receiver=user, status=MatchLeg.Status.PENDING)
 
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
         MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
@@ -66,7 +71,30 @@ class TestMatchViews:
         assert response.status_code == status.HTTP_200_OK
         returned_ids = {item['id'] for item in response.data}
         assert str(pending_match.id) in returned_ids
+        assert str(already_accepted_match.id) not in returned_ids
         assert str(completed_match.id) not in returned_ids
+
+    def test_match_list_status_filter_accepted_excludes_expired(self, api_client):
+        """EXPIRED matches (partner declined after user accepted) must not appear under status=accepted."""
+        user = UserFactory()
+        other = UserFactory()
+        api_client.force_authenticate(user=user)
+
+        # User accepted but the match expired because someone else declined.
+        expired_match = MatchFactory(status=Match.Status.EXPIRED)
+        MatchLegFactory(match=expired_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(match=expired_match, sender=other, receiver=user, status=MatchLeg.Status.DECLINED)
+
+        completed_match = MatchFactory(status=Match.Status.COMPLETED)
+        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+
+        url = reverse('match-list')
+        response = api_client.get(url, {'status': 'accepted'})
+
+        assert response.status_code == status.HTTP_200_OK
+        returned_ids = {item['id'] for item in response.data}
+        assert str(completed_match.id) in returned_ids
+        assert str(expired_match.id) not in returned_ids
 
     def test_match_list_no_filter_returns_all(self, api_client):
         """No status filter (All tab) returns matches in any status."""

--- a/apps/matching/tests/test_match_views.py
+++ b/apps/matching/tests/test_match_views.py
@@ -27,6 +27,67 @@ class TestMatchViews:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 2
 
+    def test_match_list_status_filter_accepted_shows_completed_matches(self, api_client):
+        """Completed matches (both legs accepted) must appear under status=accepted."""
+        user = UserFactory()
+        other = UserFactory()
+        api_client.force_authenticate(user=user)
+
+        completed_match = MatchFactory(status=Match.Status.COMPLETED)
+        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(match=completed_match, sender=other, receiver=user, status=MatchLeg.Status.ACCEPTED)
+
+        pending_match = MatchFactory(status=Match.Status.PENDING)
+        MatchLegFactory(match=pending_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
+
+        url = reverse('match-list')
+        response = api_client.get(url, {'status': 'accepted'})
+
+        assert response.status_code == status.HTTP_200_OK
+        returned_ids = {item['id'] for item in response.data}
+        assert str(completed_match.id) in returned_ids
+        assert str(pending_match.id) not in returned_ids
+
+    def test_match_list_status_filter_pending_excludes_completed(self, api_client):
+        """Completed matches must not appear under status=pending."""
+        user = UserFactory()
+        other = UserFactory()
+        api_client.force_authenticate(user=user)
+
+        pending_match = MatchFactory(status=Match.Status.PENDING)
+        MatchLegFactory(match=pending_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
+
+        completed_match = MatchFactory(status=Match.Status.COMPLETED)
+        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+
+        url = reverse('match-list')
+        response = api_client.get(url, {'status': 'pending'})
+
+        assert response.status_code == status.HTTP_200_OK
+        returned_ids = {item['id'] for item in response.data}
+        assert str(pending_match.id) in returned_ids
+        assert str(completed_match.id) not in returned_ids
+
+    def test_match_list_no_filter_returns_all(self, api_client):
+        """No status filter (All tab) returns matches in any status."""
+        user = UserFactory()
+        other = UserFactory()
+        api_client.force_authenticate(user=user)
+
+        pending_match = MatchFactory(status=Match.Status.PENDING)
+        MatchLegFactory(match=pending_match, sender=user, receiver=other)
+
+        completed_match = MatchFactory(status=Match.Status.COMPLETED)
+        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+
+        url = reverse('match-list')
+        response = api_client.get(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        returned_ids = {item['id'] for item in response.data}
+        assert str(pending_match.id) in returned_ids
+        assert str(completed_match.id) in returned_ids
+
     def test_match_detail(self, api_client):
         user = UserFactory()
         other = UserFactory()

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -17,26 +17,65 @@ logger = logging.getLogger(__name__)
 
 
 class MatchListView(APIView):
-    """GET /api/v1/matches/ — current user's pending/active matches."""
+    """GET /api/v1/matches/ — current user's matches, optionally filtered by status."""
 
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
         user = request.user
-        # Find all matches where the user is a sender or receiver in any leg
-        match_ids = (
-            MatchLeg.objects.filter(
+        status_filter = request.query_params.get("status", "").strip().lower()
+
+        if status_filter == "accepted":
+            # User's outgoing leg is accepted; match may be waiting for others (PENDING/PROPOSED)
+            # or fully confirmed (COMPLETED) with a trade already created.
+            match_ids = MatchLeg.objects.filter(
                 sender=user,
-                match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
-            )
-            .values_list("match_id", flat=True)
-            .union(
+                status=MatchLeg.Status.ACCEPTED,
+            ).values_list("match_id", flat=True)
+        elif status_filter == "declined":
+            match_ids = MatchLeg.objects.filter(
+                sender=user,
+                status=MatchLeg.Status.DECLINED,
+            ).values_list("match_id", flat=True)
+        elif status_filter == "proposed":
+            match_ids = (
                 MatchLeg.objects.filter(
-                    receiver=user,
-                    match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
-                ).values_list("match_id", flat=True)
+                    sender=user,
+                    match__status=Match.Status.PROPOSED,
+                )
+                .values_list("match_id", flat=True)
+                .union(
+                    MatchLeg.objects.filter(
+                        receiver=user,
+                        match__status=Match.Status.PROPOSED,
+                    ).values_list("match_id", flat=True)
+                )
             )
-        )
+        elif status_filter == "pending":
+            match_ids = (
+                MatchLeg.objects.filter(
+                    sender=user,
+                    status=MatchLeg.Status.PENDING,
+                    match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+                )
+                .values_list("match_id", flat=True)
+                .union(
+                    MatchLeg.objects.filter(
+                        receiver=user,
+                        match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+                    ).values_list("match_id", flat=True)
+                )
+            )
+        else:
+            # No filter (All tab) — every match the user participates in.
+            match_ids = (
+                MatchLeg.objects.filter(sender=user)
+                .values_list("match_id", flat=True)
+                .union(
+                    MatchLeg.objects.filter(receiver=user).values_list("match_id", flat=True)
+                )
+            )
+
         matches = (
             Match.objects.filter(id__in=match_ids)
             .prefetch_related("legs__sender", "legs__receiver", "legs__user_book__book")

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -28,9 +28,11 @@ class MatchListView(APIView):
         if status_filter == "accepted":
             # User's outgoing leg is accepted; match may be waiting for others (PENDING/PROPOSED)
             # or fully confirmed (COMPLETED) with a trade already created.
+            # Exclude EXPIRED so matches where someone else declined don't appear here.
             match_ids = MatchLeg.objects.filter(
                 sender=user,
                 status=MatchLeg.Status.ACCEPTED,
+                match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED, Match.Status.COMPLETED],
             ).values_list("match_id", flat=True)
         elif status_filter == "declined":
             match_ids = MatchLeg.objects.filter(
@@ -52,20 +54,13 @@ class MatchListView(APIView):
                 )
             )
         elif status_filter == "pending":
-            match_ids = (
-                MatchLeg.objects.filter(
-                    sender=user,
-                    status=MatchLeg.Status.PENDING,
-                    match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
-                )
-                .values_list("match_id", flat=True)
-                .union(
-                    MatchLeg.objects.filter(
-                        receiver=user,
-                        match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
-                    ).values_list("match_id", flat=True)
-                )
-            )
+            # Filter only by the user's own sender leg being PENDING so that matches
+            # where the user already accepted don't bleed through via the receiver side.
+            match_ids = MatchLeg.objects.filter(
+                sender=user,
+                status=MatchLeg.Status.PENDING,
+                match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+            ).values_list("match_id", flat=True)
         else:
             # No filter (All tab) — every match the user participates in.
             match_ids = (


### PR DESCRIPTION
## Summary
Enhanced the match list endpoint to support filtering matches by status, allowing users to view matches in different states (pending, accepted, declined, proposed, or all).

## Key Changes
- **Updated `MatchListView.get()`** to accept an optional `status` query parameter that filters matches based on:
  - `accepted`: Matches where the user's outgoing leg is accepted (includes both PENDING/PROPOSED and COMPLETED matches)
  - `declined`: Matches where the user's outgoing leg is declined
  - `proposed`: Matches in PROPOSED status (where user is sender or receiver)
  - `pending`: Matches in PENDING/PROPOSED status where user's leg is pending
  - No filter (default): Returns all matches the user participates in
  
- **Added comprehensive test coverage** with three new test cases:
  - `test_match_list_status_filter_accepted_shows_completed_matches`: Verifies completed matches appear under `status=accepted`
  - `test_match_list_status_filter_pending_excludes_completed`: Verifies completed matches are excluded from `status=pending`
  - `test_match_list_no_filter_returns_all`: Verifies unfiltered requests return all matches

## Implementation Details
- Query parameter is case-insensitive and whitespace-trimmed for robustness
- Each status filter uses appropriate `MatchLeg` status checks combined with `Match` status constraints
- The "accepted" filter includes both PENDING/PROPOSED matches (awaiting other party) and COMPLETED matches (fully confirmed with trade created)
- Uses `.union()` to combine sender and receiver queries where needed
- Maintains existing prefetch optimization for related objects

https://claude.ai/code/session_01CzQsd1bmgNaSKyGApR9KUZ