### PR TITLE
Fix match status filtering logic for pending and accepted tabs

### DIFF
--- a/apps/matching/tests/test_match_views.py
+++ b/apps/matching/tests/test_match_views.py
@@ -75,6 +75,29 @@ class TestMatchViews:
         assert str(waiting_match.id) in returned_ids  # must stay pending until partner also accepts
         assert str(completed_match.id) not in returned_ids
 
+    def test_match_list_status_filter_accepted_excludes_waiting_for_partner(self, api_client):
+        """A match where the user accepted but the partner hasn't must NOT appear under status=accepted."""
+        user = UserFactory()
+        other = UserFactory()
+        api_client.force_authenticate(user=user)
+
+        # User accepted their leg but the overall match is still PENDING (partner hasn't responded).
+        waiting_match = MatchFactory(status=Match.Status.PENDING)
+        MatchLegFactory(match=waiting_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(match=waiting_match, sender=other, receiver=user, status=MatchLeg.Status.PENDING)
+
+        completed_match = MatchFactory(status=Match.Status.COMPLETED)
+        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(match=completed_match, sender=other, receiver=user, status=MatchLeg.Status.ACCEPTED)
+
+        url = reverse('match-list')
+        response = api_client.get(url, {'status': 'accepted'})
+
+        assert response.status_code == status.HTTP_200_OK
+        returned_ids = {item['id'] for item in response.data}
+        assert str(completed_match.id) in returned_ids
+        assert str(waiting_match.id) not in returned_ids
+
     def test_match_list_status_filter_accepted_excludes_expired(self, api_client):
         """EXPIRED matches (partner declined after user accepted) must not appear under status=accepted."""
         user = UserFactory()

--- a/apps/matching/tests/test_match_views.py
+++ b/apps/matching/tests/test_match_views.py
@@ -48,8 +48,8 @@ class TestMatchViews:
         assert str(completed_match.id) in returned_ids
         assert str(pending_match.id) not in returned_ids
 
-    def test_match_list_status_filter_pending_excludes_completed(self, api_client):
-        """Completed matches and matches where the user already accepted must not appear under status=pending."""
+    def test_match_list_status_filter_pending_includes_waiting_for_partner(self, api_client):
+        """A match stays in pending for a user who has already accepted until ALL parties accept."""
         user = UserFactory()
         other = UserFactory()
         api_client.force_authenticate(user=user)
@@ -58,9 +58,10 @@ class TestMatchViews:
         MatchLegFactory(match=pending_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
 
         # User already accepted their sender leg; match is still PENDING waiting for the other party.
-        already_accepted_match = MatchFactory(status=Match.Status.PENDING)
-        MatchLegFactory(match=already_accepted_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
-        MatchLegFactory(match=already_accepted_match, sender=other, receiver=user, status=MatchLeg.Status.PENDING)
+        # This must still appear in the pending tab — not the accepted tab.
+        waiting_match = MatchFactory(status=Match.Status.PENDING)
+        MatchLegFactory(match=waiting_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(match=waiting_match, sender=other, receiver=user, status=MatchLeg.Status.PENDING)
 
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
         MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
@@ -71,7 +72,7 @@ class TestMatchViews:
         assert response.status_code == status.HTTP_200_OK
         returned_ids = {item['id'] for item in response.data}
         assert str(pending_match.id) in returned_ids
-        assert str(already_accepted_match.id) not in returned_ids
+        assert str(waiting_match.id) in returned_ids  # must stay pending until partner also accepts
         assert str(completed_match.id) not in returned_ids
 
     def test_match_list_status_filter_accepted_excludes_expired(self, api_client):

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -26,13 +26,10 @@ class MatchListView(APIView):
         status_filter = request.query_params.get("status", "").strip().lower()
 
         if status_filter == "accepted":
-            # User's outgoing leg is accepted; match may be waiting for others (PENDING/PROPOSED)
-            # or fully confirmed (COMPLETED) with a trade already created.
-            # Exclude EXPIRED so matches where someone else declined don't appear here.
+            # All legs accepted — match is fully confirmed (COMPLETED) with a trade created.
             match_ids = MatchLeg.objects.filter(
                 sender=user,
-                status=MatchLeg.Status.ACCEPTED,
-                match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED, Match.Status.COMPLETED],
+                match__status=Match.Status.COMPLETED,
             ).values_list("match_id", flat=True)
         elif status_filter == "declined":
             match_ids = MatchLeg.objects.filter(
@@ -54,11 +51,10 @@ class MatchListView(APIView):
                 )
             )
         elif status_filter == "pending":
-            # Filter only by the user's own sender leg being PENDING so that matches
-            # where the user already accepted don't bleed through via the receiver side.
+            # Show all active matches regardless of whether the user has already accepted
+            # their own leg — a match stays pending until ALL parties have accepted.
             match_ids = MatchLeg.objects.filter(
                 sender=user,
-                status=MatchLeg.Status.PENDING,
                 match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
             ).values_list("match_id", flat=True)
         else:

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -27,8 +27,11 @@ class MatchListView(APIView):
 
         if status_filter == "accepted":
             # All legs accepted — match is fully confirmed (COMPLETED) with a trade created.
+            # Constrain leg status explicitly to use the (sender, status) index and guard
+            # against any data inconsistency where a COMPLETED match has non-accepted legs.
             match_ids = MatchLeg.objects.filter(
                 sender=user,
+                status=MatchLeg.Status.ACCEPTED,
                 match__status=Match.Status.COMPLETED,
             ).values_list("match_id", flat=True)
         elif status_filter == "declined":
@@ -53,8 +56,11 @@ class MatchListView(APIView):
         elif status_filter == "pending":
             # Show all active matches regardless of whether the user has already accepted
             # their own leg — a match stays pending until ALL parties have accepted.
+            # Restrict to PENDING/ACCEPTED leg statuses to use the (sender, status) index
+            # and prevent any unexpected leg states from leaking into this tab.
             match_ids = MatchLeg.objects.filter(
                 sender=user,
+                status__in=[MatchLeg.Status.PENDING, MatchLeg.Status.ACCEPTED],
                 match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
             ).values_list("match_id", flat=True)
         else:


### PR DESCRIPTION
## Summary
This PR corrects the match status filtering logic to properly handle matches where a user has already accepted their leg but is waiting for other parties to accept theirs. Previously, such matches were incorrectly excluded from the pending tab.

## Key Changes

- **Pending tab behavior**: Changed to show all active matches (PENDING/PROPOSED status) regardless of whether the user has already accepted their own leg. A match now correctly stays in the pending tab until ALL parties have accepted.

- **Accepted tab behavior**: Restricted to only show fully completed matches (COMPLETED status) where all legs are accepted and a trade has been created. Removed the logic that incorrectly included partially-accepted matches.

- **Test updates**: 
  - Renamed test from `test_match_list_status_filter_pending_excludes_completed` to `test_match_list_status_filter_pending_includes_waiting_for_partner` to better reflect the intended behavior
  - Updated test assertions to verify that matches where the user has accepted but is waiting for their partner now correctly appear in the pending tab
  - Improved test documentation with clearer comments about expected behavior

## Implementation Details

The core fix involved removing the `status=MatchLeg.Status.PENDING` filter from the pending tab query, allowing matches where the user's sender leg is ACCEPTED to still appear as long as the overall match status is PENDING or PROPOSED. This ensures users can track matches they've accepted while waiting for other parties to respond.

https://claude.ai/code/session_013QfKFYHp6ufWWYaVseKvqX