### PR TITLE
Remove Match.Status.PENDING — all matches start as PROPOSED

### DIFF
--- a/SUPERUSER.md
+++ b/SUPERUSER.md
@@ -310,7 +310,7 @@ railway run python manage.py run_periodic_tasks --task=auto_close
 
 ### Manually Expiring Old Matches
 
-Matches in `pending` or `proposed` status that have passed their `expires_at` time will be cleaned up by the scheduled `expire_old_matches` task. To run immediately:
+Matches in `proposed` status that have passed their `expires_at` time will be cleaned up by the scheduled `expire_old_matches` task. To run immediately:
 
 ```bash
 railway run python manage.py run_periodic_tasks --task=expire_matches
@@ -340,8 +340,8 @@ Useful queries:
 -- Count users by account type
 SELECT account_type, COUNT(*) FROM accounts_user GROUP BY account_type;
 
--- All pending matches
-SELECT id, match_type, status, detected_at FROM matching_match WHERE status IN ('pending', 'proposed');
+-- All proposed matches
+SELECT id, match_type, status, detected_at FROM matching_match WHERE status = 'proposed';
 
 -- All active trades
 SELECT id, status, confirmed_at, auto_close_at FROM trading_trade WHERE status NOT IN ('completed', 'auto_closed', 'cancelled');

--- a/apps/accounts/management/commands/seed_e2e.py
+++ b/apps/accounts/management/commands/seed_e2e.py
@@ -397,7 +397,7 @@ class Command(BaseCommand):
 
     def _seed_matches(self, users, books, inventory):
         """
-        Three pending direct matches so each destructive test has its own record:
+        Three proposed direct matches so each destructive test has its own record:
           Match 1: alice(Orwell) ↔ bob(Gatsby)   — alice accepts
           Match 2: bob(Tolstoy)  ↔ carol(Chekhov) — bob declines
           Match 3: alice(Hemingway) ↔ carol(London) — carol tries to accept (address error)
@@ -433,7 +433,7 @@ class Command(BaseCommand):
 
     def _seed_one_match(self, sender_a, ub_a, sender_b, ub_b, label):
         existing = Match.objects.filter(
-            status=Match.Status.PENDING,
+            status=Match.Status.PROPOSED,
             legs__sender=sender_a,
             legs__user_book=ub_a,
         ).first()
@@ -442,7 +442,7 @@ class Command(BaseCommand):
             return
         match = Match.objects.create(
             match_type=Match.MatchType.DIRECT,
-            status=Match.Status.PENDING,
+            status=Match.Status.PROPOSED,
             expires_at=timezone.now() + timedelta(hours=48),
         )
         MatchLeg.objects.create(

--- a/apps/accounts/tests/test_auth_api.py
+++ b/apps/accounts/tests/test_auth_api.py
@@ -300,7 +300,7 @@ class TestUserMeView:
         book_a = UserBookFactory(user=user)
         book_b = UserBookFactory(user=other)
 
-        match = Match.objects.create(match_type="direct", status=Match.Status.PENDING)
+        match = Match.objects.create(match_type="direct", status=Match.Status.PROPOSED)
         MatchLeg.objects.create(
             match=match,
             sender=user,
@@ -353,7 +353,7 @@ class TestUserMeView:
         book_a = UserBookFactory(user=user)
         book_b = UserBookFactory(user=other)
 
-        match = Match.objects.create(match_type="direct", status=Match.Status.PENDING)
+        match = Match.objects.create(match_type="direct", status=Match.Status.PROPOSED)
         MatchLeg.objects.create(
             match=match,
             sender=user,

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -554,14 +554,14 @@ def _cancel_user_active_matches(user):
     from apps.matching.models import Match, MatchLeg
     from apps.trading.models import TradeProposal
 
-    # Cancel pending/proposed matches where user is either sender or receiver.
+    # Cancel proposed matches where user is either sender or receiver.
     active_leg_match_ids = MatchLeg.objects.filter(
         Q(sender=user) | Q(receiver=user),
         status__in=[MatchLeg.Status.PENDING, MatchLeg.Status.ACCEPTED],
     ).values_list("match_id", flat=True)
     Match.objects.filter(
         id__in=active_leg_match_ids,
-        status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+        status=Match.Status.PROPOSED,
     ).update(status=Match.Status.EXPIRED)
 
     # Cancel pending proposals where user is either side.

--- a/apps/matching/migrations/0002_remove_match_pending_status.py
+++ b/apps/matching/migrations/0002_remove_match_pending_status.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+def migrate_pending_to_proposed(apps, schema_editor):
+    Match = apps.get_model("matching", "Match")
+    Match.objects.filter(status="pending").update(status="proposed")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("matching", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_pending_to_proposed,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        migrations.AlterField(
+            model_name="match",
+            name="status",
+            field=models.CharField(
+                choices=[
+                    ("proposed", "Proposed"),
+                    ("expired", "Expired"),
+                    ("completed", "Completed"),
+                ],
+                default="proposed",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/apps/matching/models.py
+++ b/apps/matching/models.py
@@ -12,14 +12,13 @@ class Match(models.Model):
         RING = 'ring', 'Ring'
 
     class Status(models.TextChoices):
-        PENDING = 'pending', 'Pending'
         PROPOSED = 'proposed', 'Proposed'
         EXPIRED = 'expired', 'Expired'
         COMPLETED = 'completed', 'Completed'
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     match_type = models.CharField(max_length=10, choices=MatchType.choices)
-    status = models.CharField(max_length=20, choices=Status.choices, default=Status.PENDING)
+    status = models.CharField(max_length=20, choices=Status.choices, default=Status.PROPOSED)
     detected_at = models.DateTimeField(auto_now_add=True)
     expires_at = models.DateTimeField()
     updated_at = models.DateTimeField(auto_now=True)

--- a/apps/matching/services/direct_matcher.py
+++ b/apps/matching/services/direct_matcher.py
@@ -38,11 +38,11 @@ def _ordered_wishlist_entries_by_match_phase(wishlist_queryset):
 
 
 def count_active_matches_for_user(user) -> int:
-    """Count the number of active (pending/proposed) matches a user is involved in."""
+    """Count the number of active (proposed) matches a user is involved in."""
     match_count = (
         MatchLeg.objects.filter(
             sender=user,
-            match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+            match__status=Match.Status.PROPOSED,
         )
         .values("match")
         .distinct()
@@ -96,7 +96,7 @@ def _active_match_exists_for_user_book(user_book_id) -> bool:
     """Check if the given UserBook is already in an active match."""
     return MatchLeg.objects.filter(
         user_book_id=user_book_id,
-        match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+        match__status=Match.Status.PROPOSED,
     ).exists()
 
 
@@ -264,7 +264,7 @@ def _find_book_for_trade(user_a, user_b) -> Optional[UserBook]:
 def _duplicate_match_exists(user_a, user_b, book_a: UserBook, book_b: UserBook) -> bool:
     """Check if an equivalent active direct match already exists."""
     existing = MatchLeg.objects.filter(
-        match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+        match__status=Match.Status.PROPOSED,
         match__match_type=Match.MatchType.DIRECT,
         user_book=book_a,
         sender=user_a,

--- a/apps/matching/tasks.py
+++ b/apps/matching/tasks.py
@@ -106,13 +106,13 @@ def run_periodic_matching():
 
 def expire_old_matches():
     """
-    Periodic task — expire pending/proposed matches past their expiry time.
+    Periodic task — expire proposed matches past their expiry time.
     """
     from apps.matching.models import Match
 
     now = timezone.now()
     expired_count = Match.objects.filter(
-        status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+        status=Match.Status.PROPOSED,
         expires_at__lt=now,
     ).update(status=Match.Status.EXPIRED)
 

--- a/apps/matching/tests/test_direct_matcher.py
+++ b/apps/matching/tests/test_direct_matcher.py
@@ -51,7 +51,7 @@ class TestDirectMatcher:
         
         m1 = MatchFactory(status=Match.Status.PROPOSED)
         MatchLegFactory(match=m1, sender=user_a)
-        m2 = MatchFactory(status=Match.Status.PENDING)
+        m2 = MatchFactory(status=Match.Status.PROPOSED)
         MatchLegFactory(match=m2, sender=user_a)
         
         # Verify user A is at limit

--- a/apps/matching/tests/test_direct_matcher_duplicates.py
+++ b/apps/matching/tests/test_direct_matcher_duplicates.py
@@ -44,7 +44,7 @@ class TestDuplicateMatchExists:
 
         match = Match.objects.create(
             match_type=Match.MatchType.DIRECT,
-            status=Match.Status.PENDING,
+            status=Match.Status.PROPOSED,
         )
         MatchLeg.objects.create(
             match=match,

--- a/apps/matching/tests/test_match_views.py
+++ b/apps/matching/tests/test_match_views.py
@@ -12,18 +12,18 @@ class TestMatchViews:
         user = UserFactory()
         other = UserFactory()
         api_client.force_authenticate(user=user)
-        
+
         # Match as sender
         m1 = MatchFactory()
         MatchLegFactory(match=m1, sender=user, receiver=other)
-        
+
         # Match as receiver
         m2 = MatchFactory()
         MatchLegFactory(match=m2, sender=other, receiver=user)
-        
+
         url = reverse('match-list')
         response = api_client.get(url)
-        
+
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 2
 
@@ -37,8 +37,8 @@ class TestMatchViews:
         MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
         MatchLegFactory(match=completed_match, sender=other, receiver=user, status=MatchLeg.Status.ACCEPTED)
 
-        pending_match = MatchFactory(status=Match.Status.PENDING)
-        MatchLegFactory(match=pending_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
+        proposed_match = MatchFactory(status=Match.Status.PROPOSED)
+        MatchLegFactory(match=proposed_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
 
         url = reverse('match-list')
         response = api_client.get(url, {'status': 'accepted'})
@@ -46,20 +46,20 @@ class TestMatchViews:
         assert response.status_code == status.HTTP_200_OK
         returned_ids = {item['id'] for item in response.data}
         assert str(completed_match.id) in returned_ids
-        assert str(pending_match.id) not in returned_ids
+        assert str(proposed_match.id) not in returned_ids
 
-    def test_match_list_status_filter_pending_includes_waiting_for_partner(self, api_client):
-        """A match stays in pending for a user who has already accepted until ALL parties accept."""
+    def test_match_list_status_filter_proposed_includes_waiting_for_partner(self, api_client):
+        """A match stays in proposed for a user who has already accepted until ALL parties accept."""
         user = UserFactory()
         other = UserFactory()
         api_client.force_authenticate(user=user)
 
-        pending_match = MatchFactory(status=Match.Status.PENDING)
-        MatchLegFactory(match=pending_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
+        proposed_match = MatchFactory(status=Match.Status.PROPOSED)
+        MatchLegFactory(match=proposed_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
 
-        # User already accepted their sender leg; match is still PENDING waiting for the other party.
-        # This must still appear in the pending tab — not the accepted tab.
-        waiting_match = MatchFactory(status=Match.Status.PENDING)
+        # User already accepted their sender leg; match is still PROPOSED waiting for the other party.
+        # This must still appear in the proposed tab — not the accepted tab.
+        waiting_match = MatchFactory(status=Match.Status.PROPOSED)
         MatchLegFactory(match=waiting_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
         MatchLegFactory(match=waiting_match, sender=other, receiver=user, status=MatchLeg.Status.PENDING)
 
@@ -67,12 +67,12 @@ class TestMatchViews:
         MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
 
         url = reverse('match-list')
-        response = api_client.get(url, {'status': 'pending'})
+        response = api_client.get(url, {'status': 'proposed'})
 
         assert response.status_code == status.HTTP_200_OK
         returned_ids = {item['id'] for item in response.data}
-        assert str(pending_match.id) in returned_ids
-        assert str(waiting_match.id) in returned_ids  # must stay pending until partner also accepts
+        assert str(proposed_match.id) in returned_ids
+        assert str(waiting_match.id) in returned_ids  # must stay proposed until partner also accepts
         assert str(completed_match.id) not in returned_ids
 
     def test_match_list_status_filter_accepted_excludes_waiting_for_partner(self, api_client):
@@ -81,8 +81,8 @@ class TestMatchViews:
         other = UserFactory()
         api_client.force_authenticate(user=user)
 
-        # User accepted their leg but the overall match is still PENDING (partner hasn't responded).
-        waiting_match = MatchFactory(status=Match.Status.PENDING)
+        # User accepted their leg but the overall match is still PROPOSED (partner hasn't responded).
+        waiting_match = MatchFactory(status=Match.Status.PROPOSED)
         MatchLegFactory(match=waiting_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
         MatchLegFactory(match=waiting_match, sender=other, receiver=user, status=MatchLeg.Status.PENDING)
 
@@ -126,8 +126,8 @@ class TestMatchViews:
         other = UserFactory()
         api_client.force_authenticate(user=user)
 
-        pending_match = MatchFactory(status=Match.Status.PENDING)
-        MatchLegFactory(match=pending_match, sender=user, receiver=other)
+        proposed_match = MatchFactory(status=Match.Status.PROPOSED)
+        MatchLegFactory(match=proposed_match, sender=user, receiver=other)
 
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
         MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
@@ -137,33 +137,33 @@ class TestMatchViews:
 
         assert response.status_code == status.HTTP_200_OK
         returned_ids = {item['id'] for item in response.data}
-        assert str(pending_match.id) in returned_ids
+        assert str(proposed_match.id) in returned_ids
         assert str(completed_match.id) in returned_ids
 
     def test_match_detail(self, api_client):
         user = UserFactory()
         other = UserFactory()
         api_client.force_authenticate(user=user)
-        
+
         match = MatchFactory()
         MatchLegFactory(match=match, sender=user, receiver=other)
-        
+
         url = reverse('match-detail', kwargs={'pk': match.pk})
         response = api_client.get(url)
-        
+
         assert response.status_code == status.HTTP_200_OK
         assert response.data['id'] == str(match.id)
 
     def test_match_detail_not_participant(self, api_client):
         user = UserFactory()
         api_client.force_authenticate(user=user)
-        
+
         match = MatchFactory()
         MatchLegFactory(match=match, sender=UserFactory(), receiver=UserFactory())
-        
+
         url = reverse('match-detail', kwargs={'pk': match.pk})
         response = api_client.get(url)
-        
+
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @patch("apps.matching.views.user_has_verified_shipping_address", return_value=True)
@@ -171,27 +171,27 @@ class TestMatchViews:
     def test_match_accept_success(self, mock_create_trade, mock_verify, api_client):
         user_a = UserFactory()
         user_b = UserFactory()
-        
+
         match = MatchFactory()
         # Direct match: A sends to B, B sends to A
         leg_a = MatchLegFactory(match=match, sender=user_a, receiver=user_b)
         leg_b = MatchLegFactory(match=match, sender=user_b, receiver=user_a)
-        
+
         url = reverse('match-accept', kwargs={'pk': match.pk})
-        
+
         # User A accepts
         api_client.force_authenticate(user=user_a)
         response = api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
-        
+
         leg_a.refresh_from_db()
         assert leg_a.status == MatchLeg.Status.ACCEPTED
-        
+
         # User B accepts
         api_client.force_authenticate(user=user_b)
         response = api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
-        
+
         match.refresh_from_db()
         assert match.status == Match.Status.COMPLETED
         assert mock_create_trade.called
@@ -199,26 +199,26 @@ class TestMatchViews:
     def test_match_accept_no_address(self, api_client):
         user = UserFactory(address_verification_status='unverified')
         api_client.force_authenticate(user=user)
-        
+
         match = MatchFactory()
         MatchLegFactory(match=match, sender=user, receiver=UserFactory())
-        
+
         url = reverse('match-accept', kwargs={'pk': match.pk})
         response = api_client.post(url)
-        
+
         assert response.status_code == status.HTTP_409_CONFLICT
         assert response.data['code'] == 'address_verification_required'
 
     def test_match_decline(self, api_client):
         user = UserFactory()
         api_client.force_authenticate(user=user)
-        
+
         match = MatchFactory(match_type=Match.MatchType.DIRECT)
         leg = MatchLegFactory(match=match, sender=user, receiver=UserFactory())
-        
+
         url = reverse('match-decline', kwargs={'pk': match.pk})
         response = api_client.post(url)
-        
+
         assert response.status_code == status.HTTP_200_OK
         leg.refresh_from_db()
         assert leg.status == MatchLeg.Status.DECLINED
@@ -229,12 +229,12 @@ class TestMatchViews:
     def test_match_decline_ring_retry(self, mock_on_commit, api_client):
         user = UserFactory()
         api_client.force_authenticate(user=user)
-        
+
         match = MatchFactory(match_type=Match.MatchType.RING)
         MatchLegFactory(match=match, sender=user, receiver=UserFactory())
-        
+
         url = reverse('match-decline', kwargs={'pk': match.pk})
         response = api_client.post(url)
-        
+
         assert response.status_code == status.HTTP_200_OK
         assert mock_on_commit.called

--- a/apps/matching/tests/test_matching.py
+++ b/apps/matching/tests/test_matching.py
@@ -117,7 +117,7 @@ class TestDirectMatcherService:
         other_user_1 = UserFactory()
         other_ub_1 = UserBookFactory(user=user_a, book=other_book_1, condition="good")
         existing_match_1 = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=existing_match_1,
@@ -130,7 +130,7 @@ class TestDirectMatcherService:
         other_user_2 = UserFactory()
         other_ub_2 = UserBookFactory(user=user_a, book=other_book_2, condition="good")
         existing_match_2 = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=existing_match_2,
@@ -452,7 +452,7 @@ class TestCountActiveMatches:
         book = BookFactory()
         ub = UserBookFactory(user=user, book=book)
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(match=match, sender=user, receiver=other, user_book=ub)
         assert count_active_matches_for_user(user) == 1
@@ -514,7 +514,7 @@ class TestMatchAPI:
         ub_b = UserBookFactory(user=other, book=book_b, condition="good")
 
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         leg_a = MatchLeg.objects.create(
             match=match,
@@ -544,7 +544,7 @@ class TestMatchAPI:
         ub_b = UserBookFactory(user=other, book=book_b, condition="good")
 
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=match, sender=verified_user, receiver=other, user_book=ub_a
@@ -575,7 +575,7 @@ class TestMatchAPI:
         ub_b = UserBookFactory(user=other, book=book_b, condition="good")
 
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=match, sender=verified_user, receiver=other, user_book=ub_a
@@ -606,7 +606,7 @@ class TestMatchAPI:
         ub_b = UserBookFactory(user=other, book=book_b, condition="good")
 
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=match, sender=verified_user, receiver=other, user_book=ub_a
@@ -627,7 +627,7 @@ class TestMatchAPI:
         ub_b = UserBookFactory(user=other, book=book_b, condition="good")
 
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=match, sender=verified_user, receiver=other, user_book=ub_a
@@ -754,7 +754,7 @@ class TestMatchAPI:
         book = BookFactory()
         ub = UserBookFactory(user=user_x, book=book)
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=match, sender=user_x, receiver=user_y, user_book=ub
@@ -769,7 +769,7 @@ class TestMatchAPI:
         book = BookFactory()
         ub = UserBookFactory(user=other_a, book=book)
         unrelated_match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=unrelated_match, sender=other_a, receiver=other_b, user_book=ub
@@ -793,7 +793,7 @@ class TestMatchDetailView:
         other = UserFactory()
         ub = UserBookFactory(user=verified_user)
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=match, sender=verified_user, receiver=other, user_book=ub, position=0
@@ -823,7 +823,7 @@ class TestMatchDetailView:
         user_a = UserFactory()
         user_b = UserFactory()
         match = Match.objects.create(
-            match_type=Match.MatchType.DIRECT, status=Match.Status.PENDING
+            match_type=Match.MatchType.DIRECT, status=Match.Status.PROPOSED
         )
         MatchLeg.objects.create(
             match=match,

--- a/apps/matching/tests/test_matching_tasks.py
+++ b/apps/matching/tests/test_matching_tasks.py
@@ -46,7 +46,7 @@ class TestMatchingTasks:
         assert mock_ring.called
 
     def test_expire_old_matches(self):
-        m1 = MatchFactory(status=Match.Status.PENDING, expires_at=timezone.now() - timedelta(hours=1))
+        m1 = MatchFactory(status=Match.Status.PROPOSED, expires_at=timezone.now() - timedelta(hours=1))
         m2 = MatchFactory(status=Match.Status.PROPOSED, expires_at=timezone.now() + timedelta(hours=1))
         
         expire_old_matches()

--- a/apps/matching/tests/test_ring_detector.py
+++ b/apps/matching/tests/test_ring_detector.py
@@ -54,7 +54,7 @@ class TestRingDetector:
         user_a = UserFactory(email_verified=True)
         # capacity default is 2
         MatchLegFactory(match=MatchFactory(status=Match.Status.PROPOSED), sender=user_a)
-        MatchLegFactory(match=MatchFactory(status=Match.Status.PENDING), sender=user_a)
+        MatchLegFactory(match=MatchFactory(status=Match.Status.PROPOSED), sender=user_a)
         
         user_b = UserFactory(email_verified=True)
         user_c = UserFactory(email_verified=True)

--- a/apps/matching/tests/test_tasks.py
+++ b/apps/matching/tests/test_tasks.py
@@ -41,7 +41,7 @@ class TestMatchingTasks:
 
         matches = Match.objects.filter(
             match_type=Match.MatchType.DIRECT,
-            status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+            status=Match.Status.PROPOSED,
         )
         assert matches.count() == 1
 
@@ -65,7 +65,7 @@ class TestMatchingTasks:
 
         matches = Match.objects.filter(
             match_type=Match.MatchType.DIRECT,
-            status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+            status=Match.Status.PROPOSED,
         )
         assert matches.count() == 1
         assert matches.first().legs.filter(user_book=user_book).exists()
@@ -98,7 +98,7 @@ class TestMatchingTasks:
         now = timezone.now()
         expired_pending = Match.objects.create(
             match_type=Match.MatchType.DIRECT,
-            status=Match.Status.PENDING,
+            status=Match.Status.PROPOSED,
             expires_at=now - timedelta(minutes=1),
         )
         expired_proposed = Match.objects.create(
@@ -108,7 +108,7 @@ class TestMatchingTasks:
         )
         future_pending = Match.objects.create(
             match_type=Match.MatchType.DIRECT,
-            status=Match.Status.PENDING,
+            status=Match.Status.PROPOSED,
             expires_at=now + timedelta(hours=1),
         )
         already_completed = Match.objects.create(
@@ -126,7 +126,7 @@ class TestMatchingTasks:
 
         assert expired_pending.status == Match.Status.EXPIRED
         assert expired_proposed.status == Match.Status.EXPIRED
-        assert future_pending.status == Match.Status.PENDING
+        assert future_pending.status == Match.Status.PROPOSED
         assert already_completed.status == Match.Status.COMPLETED
 
     def test_retry_ring_after_decline_task_queues_notification_when_reformed(self):
@@ -250,7 +250,7 @@ class TestMatchingTaskEdgeCases:
 
         assert Match.objects.filter(
             match_type=Match.MatchType.DIRECT,
-            status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+            status=Match.Status.PROPOSED,
         ).exists()
 
     def test_run_matching_for_relisted_books_no_books_is_silent(self):
@@ -284,7 +284,7 @@ class TestMatchingTaskEdgeCases:
         book = BookFactory()
         direct = Match.objects.create(
             match_type=Match.MatchType.DIRECT,
-            status=Match.Status.PENDING,
+            status=Match.Status.PROPOSED,
         )
         ub = UserBookFactory(user=user_a, book=book)
         from apps.matching.models import MatchLeg

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -53,16 +53,6 @@ class MatchListView(APIView):
                     ).values_list("match_id", flat=True)
                 )
             )
-        elif status_filter == "pending":
-            # Show all active matches regardless of whether the user has already accepted
-            # their own leg — a match stays pending until ALL parties have accepted.
-            # Restrict to PENDING/ACCEPTED leg statuses to use the (sender, status) index
-            # and prevent any unexpected leg states from leaking into this tab.
-            match_ids = MatchLeg.objects.filter(
-                sender=user,
-                status__in=[MatchLeg.Status.PENDING, MatchLeg.Status.ACCEPTED],
-                match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
-            ).values_list("match_id", flat=True)
         else:
             # No filter (All tab) — every match the user participates in.
             match_ids = (
@@ -116,7 +106,7 @@ class MatchAcceptView(APIView):
         try:
             match = Match.objects.prefetch_related("legs").get(
                 pk=pk,
-                status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+                status=Match.Status.PROPOSED,
             )
         except Match.DoesNotExist:
             return Response(
@@ -185,7 +175,7 @@ class MatchDeclineView(APIView):
         try:
             match = Match.objects.prefetch_related("legs").get(
                 pk=pk,
-                status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+                status=Match.Status.PROPOSED,
             )
         except Match.DoesNotExist:
             return Response(
@@ -315,12 +305,12 @@ class ReverseDiscoveryView(APIView):
         # 3. Identify partners with existing active matches to exclude
         active_match_partner_ids = set(
             MatchLeg.objects.filter(
-                match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+                match__status=Match.Status.PROPOSED,
                 sender=user,
             ).values_list("receiver_id", flat=True)
         ) | set(
             MatchLeg.objects.filter(
-                match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED],
+                match__status=Match.Status.PROPOSED,
                 receiver=user,
             ).values_list("sender_id", flat=True)
         )

--- a/apps/notifications/tests/test_notifications.py
+++ b/apps/notifications/tests/test_notifications.py
@@ -142,7 +142,7 @@ class TestNotificationCountsView:
         user = UserFactory()
         other = UserFactory()
 
-        pending_match = Match.objects.create(match_type="direct", status="pending")
+        pending_match = Match.objects.create(match_type="direct", status="proposed")
         MatchLeg.objects.create(
             match=pending_match,
             sender=user,
@@ -166,9 +166,9 @@ class TestNotificationCountsView:
             user_book=UserBookFactory(user=user),
         )
 
-        TradeProposal.objects.create(recipient=user, proposer=other, status="pending")
+        TradeProposal.objects.create(recipient=user, proposer=other, status="proposed")
         TradeProposal.objects.create(recipient=user, proposer=other, status="accepted")
-        TradeProposal.objects.create(recipient=other, proposer=user, status="pending")
+        TradeProposal.objects.create(recipient=other, proposer=user, status="proposed")
 
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=True)

--- a/apps/notifications/tests/test_notifications.py
+++ b/apps/notifications/tests/test_notifications.py
@@ -166,9 +166,9 @@ class TestNotificationCountsView:
             user_book=UserBookFactory(user=user),
         )
 
-        TradeProposal.objects.create(recipient=user, proposer=other, status="proposed")
+        TradeProposal.objects.create(recipient=user, proposer=other, status="pending")
         TradeProposal.objects.create(recipient=user, proposer=other, status="accepted")
-        TradeProposal.objects.create(recipient=other, proposer=user, status="proposed")
+        TradeProposal.objects.create(recipient=other, proposer=user, status="pending")
 
         NotificationFactory(user=user, is_read=False)
         NotificationFactory(user=user, is_read=True)

--- a/apps/notifications/tests/test_tasks.py
+++ b/apps/notifications/tests/test_tasks.py
@@ -285,7 +285,7 @@ class TestSendMatchNotificationTask:
         user_b = UserFactory()
         book_a = UserBookFactory(user=user_a)
         book_b = UserBookFactory(user=user_b)
-        match = Match.objects.create(match_type="direct", status="pending")
+        match = Match.objects.create(match_type="direct", status="proposed")
         MatchLeg.objects.create(
             match=match, sender=user_a, receiver=user_b, user_book=book_a, position=0
         )
@@ -308,7 +308,7 @@ class TestSendMatchNotificationTask:
 
         users = [UserFactory() for _ in range(3)]
         books = [UserBookFactory(user=u) for u in users]
-        match = Match.objects.create(match_type="ring", status="pending")
+        match = Match.objects.create(match_type="ring", status="proposed")
         for i, (u, b) in enumerate(zip(users, books)):
             MatchLeg.objects.create(
                 match=match,

--- a/apps/notifications/views.py
+++ b/apps/notifications/views.py
@@ -63,7 +63,7 @@ class PendingCountsView(APIView):
 
         pending_matches = (
             MatchLeg.objects.filter(
-                match__status__in=[Match.Status.PENDING, Match.Status.PROPOSED]
+                match__status=Match.Status.PROPOSED
             )
             .filter(Q(sender=request.user) | Q(receiver=request.user))
             .values("match_id")

--- a/apps/tests/factories.py
+++ b/apps/tests/factories.py
@@ -117,7 +117,7 @@ class MatchFactory(factory.django.DjangoModelFactory):
         model = Match
 
     match_type = Match.MatchType.DIRECT
-    status = Match.Status.PENDING
+    status = Match.Status.PROPOSED
 
 
 class MatchLegFactory(factory.django.DjangoModelFactory):

--- a/apps/trading/tests/test_trading_api.py
+++ b/apps/trading/tests/test_trading_api.py
@@ -737,7 +737,7 @@ class TestTradePipelineIntegration:
 
         match = Match.objects.create(
             match_type=Match.MatchType.DIRECT,
-            status=Match.Status.PENDING,
+            status=Match.Status.PROPOSED,
         )
         MatchLeg.objects.create(
             match=match,

--- a/docs/bookswap-architecture.md
+++ b/docs/bookswap-architecture.md
@@ -158,7 +158,7 @@ INDEX: (book_id, is_active) — for matching queries
 Match
 ├── id                  UUID, primary key
 ├── match_type          ENUM: 'direct', 'ring'
-├── status              ENUM: 'pending', 'proposed', 'expired', 'completed'
+├── status              ENUM: 'proposed', 'expired', 'completed'
 ├── detected_at         timestamp
 ├── expires_at          timestamp (auto-expire if not acted on)
 └── updated_at          timestamp
@@ -179,7 +179,7 @@ INDEX on MatchLeg: (sender_id, status), (receiver_id, status)
 **Notes:**
 - A **direct match** has exactly 2 legs: A→B and B→A.
 - An **exchange ring** has 3+ legs: A→B, B→C, C→A.
-- A match moves to `proposed` when the system notifies users. All legs must be `accepted` for the match to proceed.
+- All detected matches start as `proposed`. All legs must be `accepted` for the match to proceed.
 - If any leg is `declined`, the entire match is cancelled and re-detection can find alternatives.
 
 ### TradeProposals (User-Initiated, Including Post-Match Browse)
@@ -417,7 +417,7 @@ If any leg in a ring is declined:
 
 **Deduplication:**
 - Don't create a match if an equivalent active match already exists.
-- A UserBook can only be in one active (pending/proposed) match at a time.
+- A UserBook can only be in one active (proposed) match at a time.
 
 **Match Discovery (Reverse Match):**
 This is a user-initiated discovery path that finds potential partners when no mutual match exists.
@@ -521,7 +521,7 @@ Formula: max_active_matches = min(max(rating_count, 1), 10)
 
 **Enforcement:**
 - Checked when the system proposes a match or a user creates a trade proposal.
-- "Active match" = any Match or TradeProposal in a non-terminal state (pending, proposed, accepted, shipping).
+- "Active match" = any Match or TradeProposal in a non-terminal state (proposed, accepted, shipping).
 - If a user is at their limit, new matches involving them are deferred (not lost — re-detected on next scan after a slot opens).
 
 ### 8. Email Verification
@@ -544,7 +544,7 @@ User registers with email + password
 Daily background task scans all users:
 
 1 month since last_active_at (no warning sent yet):
-    → Send "We miss you" email with summary of any pending matches
+    → Send "We miss you" email with summary of any proposed matches
     → Set inactivity_warned_1m = now()
 
 2 months since last_active_at (1m warning sent, no 2m warning):
@@ -621,7 +621,7 @@ User requests deletion → POST /api/v1/users/me/ (DELETE)
 │   └── DELETE :id/                    # Remove from wishlist
 │
 ├── matches/
-│   ├── GET    /                       # My pending/active matches
+│   ├── GET    /                       # My proposed/active matches
 │   ├── GET    discovery/reverse/      # Find partners who want my books
 │   ├── GET    :id/                    # Match detail (legs, books, users)
 │   ├── POST   :id/accept/            # Accept my leg

--- a/frontend/e2e/page-objects/MatchesPage.js
+++ b/frontend/e2e/page-objects/MatchesPage.js
@@ -5,7 +5,7 @@ export class MatchesPage {
   constructor(page) {
     this.page = page;
     this.heading = page.getByRole('heading', { name: /matches/i });
-    this.pendingTab = page.getByRole('button', { name: /^pending$/i });
+    this.proposedTab = page.getByRole('button', { name: /^proposed$/i });
     this.acceptedTab = page.getByRole('button', { name: /^accepted$/i });
     this.declinedTab = page.getByRole('button', { name: /^declined$/i });
     this.allTab = page.getByRole('button', { name: /^all$/i });

--- a/frontend/e2e/specs/critical/04-matches.spec.js
+++ b/frontend/e2e/specs/critical/04-matches.spec.js
@@ -2,7 +2,7 @@
  * critical/04-matches.spec.js
  *
  * Matches page flows:
- *   - Pending tab shows seeded match
+ *   - Proposed tab shows seeded match
  *   - Alice (address verified) can accept a match
  *   - Carol (no address) gets an address-verification error
  *   - Decline a match
@@ -10,16 +10,16 @@
 import { test, expect } from '../../fixtures/index.js';
 
 test.describe('Matches', () => {
-  test('page loads with pending matches', async ({ alicePage: page }) => {
+  test('page loads with proposed matches', async ({ alicePage: page }) => {
     await page.goto('/matches');
     await expect(page.getByRole('heading', { name: /matches/i })).toBeVisible();
 
-    // Pending tab is active by default
-    const pendingTab = page.getByRole('button', { name: /pending/i });
-    await expect(pendingTab).toBeVisible();
+    // Proposed tab is active by default
+    const proposedTab = page.getByRole('button', { name: /proposed/i });
+    await expect(proposedTab).toBeVisible();
   });
 
-  test('alice sees seeded pending match (Orwell ↔ Gatsby)', async ({ alicePage: page }) => {
+  test('alice sees seeded proposed match (Orwell ↔ Gatsby)', async ({ alicePage: page }) => {
     await page.goto('/matches');
 
     // Wait for match cards to load
@@ -34,40 +34,40 @@ test.describe('Matches', () => {
     await expect(page.getByRole('button', { name: /decline/i }).first()).toBeVisible();
   });
 
-  test('alice can accept a pending match', async ({ alicePage: page }) => {
+  test('alice can accept a proposed match', async ({ alicePage: page }) => {
     await page.goto('/matches');
     await page.waitForLoadState('networkidle');
 
-    // Count pending matches
+    // Count proposed matches
     const matchCards = page.locator('[class*="matchCard"]');
     await expect(matchCards.first()).toBeVisible({ timeout: 10_000 });
 
-    // Accept the first pending match
+    // Accept the first proposed match
     await page.getByRole('button', { name: /accept match/i }).first().click();
 
-    // Card should move away from pending tab OR a success state appears
-    // Give the mutation time to resolve and query to invalidate
+    // Card should show "Waiting for partner…" (match stays in Proposed tab until both accept)
+    // or the tab becomes empty if this was the only match
     await expect(
-      page.getByText(/accepted|no pending matches/i)
+      page.getByText(/waiting for partner|no proposed matches/i)
     ).toBeVisible({ timeout: 12_000 });
   });
 
-  test('bob can decline a pending match', async ({ bobPage: page }) => {
+  test('bob can decline a proposed match', async ({ bobPage: page }) => {
     await page.goto('/matches');
     await page.waitForLoadState('networkidle');
 
     const declineBtn = page.getByRole('button', { name: /^decline$/i }).first();
-    // Only proceed if bob still has a pending match; otherwise skip gracefully
+    // Only proceed if bob still has a proposed match; otherwise skip gracefully
     const count = await declineBtn.count();
     if (count === 0) {
-      test.skip(true, 'No pending matches for bob — may have been accepted in prior test');
+      test.skip(true, 'No proposed matches for bob — may have been accepted in prior test');
       return;
     }
 
     await declineBtn.click();
 
     await expect(
-      page.getByText(/declined|no pending matches/i)
+      page.getByText(/declined|no proposed matches/i)
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -81,8 +81,8 @@ test.describe('Matches', () => {
     const acceptBtn = page.getByRole('button', { name: /accept match/i }).first();
     const count = await acceptBtn.count();
     if (count === 0) {
-      // Carol may have no pending matches — this test is conditional
-      test.skip(true, 'No pending matches for carol');
+      // Carol may have no proposed matches — this test is conditional
+      test.skip(true, 'No proposed matches for carol');
       return;
     }
 

--- a/frontend/e2e/specs/critical/09-account-deletion.spec.js
+++ b/frontend/e2e/specs/critical/09-account-deletion.spec.js
@@ -177,9 +177,9 @@ test.describe.serial('Account deletion — happy path and downstream effects', (
       );
 
       // 4a. Dave's pending match with carol should now be CANCELLED.
-      // Filter for pending matches only (status=pending excludes EXPIRED/COMPLETED),
+      // Filter for proposed matches only (status=proposed excludes EXPIRED/COMPLETED),
       // so if the dave↔carol match was correctly cancelled it will be absent.
-      const pendingMatches = await apiListMatches(page.request, carolToken, { status: 'pending' });
+      const pendingMatches = await apiListMatches(page.request, carolToken, { status: 'proposed' });
       const pendingMatchWithDave = (Array.isArray(pendingMatches) ? pendingMatches : []).find(
         (m) =>
           m.legs?.some(

--- a/frontend/e2e/specs/critical/10-dashboard.spec.js
+++ b/frontend/e2e/specs/critical/10-dashboard.spec.js
@@ -29,7 +29,7 @@ test.describe('Dashboard', () => {
       await spinner.first().waitFor({ state: 'hidden', timeout: 15_000 });
     }
 
-    await expect(page.getByText(/pending matches/i)).toBeVisible();
+    await expect(page.getByText(/proposed matches/i)).toBeVisible();
     await expect(page.getByText(/pending proposals/i)).toBeVisible();
     await expect(page.getByText(/active trades/i)).toBeVisible();
     await expect(page.getByText(/total trades/i)).toBeVisible();

--- a/frontend/e2e/specs/critical/10-dashboard.spec.js
+++ b/frontend/e2e/specs/critical/10-dashboard.spec.js
@@ -61,7 +61,7 @@ test.describe('Dashboard', () => {
     expect(count).toBeGreaterThanOrEqual(4);
   });
 
-  test('Pending Matches card links to /matches', async ({ alicePage: page }) => {
+  test('Proposed Matches card links to /matches', async ({ alicePage: page }) => {
     await page.goto('/dashboard');
     await page.waitForLoadState('networkidle');
 
@@ -70,8 +70,8 @@ test.describe('Dashboard', () => {
       await spinner.first().waitFor({ state: 'hidden', timeout: 15_000 });
     }
 
-    // Click the card containing "Pending Matches" label
-    await page.getByText(/pending matches/i).first().click();
+    // Click the card containing "Proposed Matches" label
+    await page.getByText(/proposed matches/i).first().click();
     await expect(page).toHaveURL(/\/matches/, { timeout: 8_000 });
   });
 

--- a/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
+++ b/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
@@ -50,11 +50,11 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
 
   // ── Step 1: Alice accepts ──────────────────────────────────────────────────
 
-  test('alice sees the pending match and accepts it', async ({ alicePage: page }) => {
+  test('alice sees the proposed match and accepts it', async ({ alicePage: page }) => {
     await page.goto('/matches');
     await page.waitForLoadState('networkidle');
 
-    // Default tab is "Pending" — find the card containing Alice's book
+    // Default tab is "Proposed" — find the card containing Alice's book
     const matchCard = page.locator('[class*="matchCard"]').filter({ hasText: ALICE_SENDS });
     await expect(matchCard).toBeVisible({ timeout: 10_000 });
 
@@ -62,16 +62,11 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
     await expect(matchCard.getByRole('button', { name: /accept match/i })).toBeVisible();
     await matchCard.getByRole('button', { name: /accept match/i }).click();
 
-    // Accepting moves Alice's sender leg to ACCEPTED, removing it from the Pending
-    // tab (which only shows legs with status=PENDING). Switch to Accepted tab to
-    // confirm the card is there and shows "Waiting for partner…" (match is still
-    // PROPOSED waiting for Bob).
-    await page.getByRole('button', { name: /^accepted$/i }).click();
-    await page.waitForLoadState('networkidle');
-
-    const acceptedCard = page.locator('[class*="matchCard"]').filter({ hasText: ALICE_SENDS });
-    await expect(acceptedCard).toBeVisible({ timeout: 10_000 });
-    await expect(acceptedCard.getByText(/waiting for partner/i)).toBeVisible({ timeout: 8_000 });
+    // After accepting, the match stays in the Proposed tab (it's still PROPOSED,
+    // waiting for Bob). The card switches from showing action buttons to showing
+    // "Waiting for partner…".
+    const updatedCard = page.locator('[class*="matchCard"]').filter({ hasText: ALICE_SENDS });
+    await expect(updatedCard.getByText(/waiting for partner/i)).toBeVisible({ timeout: 8_000 });
   });
 
   // ── Step 2: Bob accepts ───────────────────────────────────────────────────
@@ -80,16 +75,16 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
     await page.goto('/matches');
     await page.waitForLoadState('networkidle');
 
-    // Bob's card shows his outgoing book (Crime and Punishment) in the Pending tab
+    // Bob's card shows his outgoing book (Crime and Punishment) in the Proposed tab
     const matchCard = page.locator('[class*="matchCard"]').filter({ hasText: BOB_SENDS });
     await expect(matchCard).toBeVisible({ timeout: 10_000 });
 
     await expect(matchCard.getByRole('button', { name: /accept match/i })).toBeVisible();
     await matchCard.getByRole('button', { name: /accept match/i }).click();
 
-    // After both accept the match moves to COMPLETED → leaves the Pending tab for Bob too.
-    // Switch to Accepted tab to confirm the card appears there (Bob may still have
-    // other seeded pending matches so we can't assume the tab becomes empty).
+    // After both accept the match moves to COMPLETED → appears in the Accepted tab.
+    // Switch to Accepted tab to confirm (Bob may still have other seeded proposed
+    // matches so we can't assume the Proposed tab becomes empty).
     await page.getByRole('button', { name: /^accepted$/i }).click();
     await page.waitForLoadState('networkidle');
 

--- a/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
+++ b/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
@@ -4,8 +4,8 @@
  * End-to-end test for the complete book-swap lifecycle:
  *
  *   1.  beforeAll seeds two dedicated books and runs direct matching synchronously.
- *   2.  Alice sees the pending match and accepts it via the UI.
- *   3.  Bob sees the pending match and accepts it via the UI.
+ *   2.  Alice sees the proposed match and accepts it via the UI.
+ *   3.  Bob sees the proposed match and accepts it via the UI.
  *   4.  Both users see the completed match in the "Accepted" tab.
  *   5.  A confirmed trade appears in each user's Trades list.
  *   6.  Alice opens the trade detail, enters a tracking number, and marks shipped.

--- a/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
+++ b/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
@@ -208,13 +208,10 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await expect(matchCard.getByRole('button', { name: /accept match/i })).toBeVisible();
     await matchCard.getByRole('button', { name: /accept match/i }).click();
 
-    // Alice's leg → ACCEPTED → card leaves Pending tab; switch to Accepted tab
-    await page.getByRole('button', { name: /^accepted$/i }).click();
-    await page.waitForLoadState('networkidle');
-
-    const acceptedCard = page.locator('[class*="matchCard"]').filter({ hasText: ALICE_SENDS });
-    await expect(acceptedCard).toBeVisible({ timeout: 10_000 });
-    await expect(acceptedCard.getByText(/waiting for partner/i)).toBeVisible({ timeout: 8_000 });
+    // Alice's leg → ACCEPTED → match stays in Proposed tab (still waiting for Bob).
+    // The card switches from action buttons to "Waiting for partner…".
+    const updatedCard = page.locator('[class*="matchCard"]').filter({ hasText: ALICE_SENDS });
+    await expect(updatedCard.getByText(/waiting for partner/i)).toBeVisible({ timeout: 8_000 });
   });
 
   // ── Step 7: Bob accepts ───────────────────────────────────────────────────

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.1",
         "@radix-ui/react-accordion": "^1.2.2",
-        "@radix-ui/react-popover": "^1.1.5",
+        "@radix-ui/react-popover": "^1.1.15",
         "@tanstack/react-query": "^5.59.20",
         "axios": "^1.7.7",
         "barcode-detector": "^3.1.2",

--- a/frontend/src/adapters/matches.test.js
+++ b/frontend/src/adapters/matches.test.js
@@ -6,7 +6,7 @@ describe('matches adapter', () => {
   it('maps books and partner from legs for the current user', () => {
     const match = {
       id: 'm1',
-      status: 'pending',
+      status: 'proposed',
       legs: [
         {
           sender: { id: 'u1', username: 'me' },

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -17,8 +17,8 @@ export default function Dashboard() {
   });
 
   const { data: matchesData, isLoading: matchesLoading } = useQuery({
-    queryKey: ['matches', 'pending'],
-    queryFn: () => matchesApi.list({ status: 'pending', page_size: 5 }).then((r) => r.data),
+    queryKey: ['matches', 'proposed'],
+    queryFn: () => matchesApi.list({ status: 'proposed', page_size: 5 }).then((r) => r.data),
   });
 
   const { data: proposalsData, isLoading: proposalsLoading } = useQuery({

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -99,7 +99,7 @@ export default function Dashboard() {
               </div>
               <div>
                 <p className={styles.summaryValue}>{activeMatchesCount}</p>
-                <p className={styles.summaryLabel}>Pending Matches</p>
+                <p className={styles.summaryLabel}>Proposed Matches</p>
               </div>
             </Link>
 

--- a/frontend/src/pages/Dashboard.test.jsx
+++ b/frontend/src/pages/Dashboard.test.jsx
@@ -89,7 +89,7 @@ describe('Dashboard page', () => {
         renderWithProviders(<Dashboard />);
 
         expect(await screen.findByText('Welcome back, alice!')).toBeInTheDocument();
-        expect(screen.getByText('Pending Matches')).toBeInTheDocument();
+        expect(screen.getByText('Proposed Matches')).toBeInTheDocument();
         expect(screen.getByText('Pending Proposals')).toBeInTheDocument();
         expect(screen.getAllByText('Active Trades')).toHaveLength(2);
         expect(screen.getByText('New Matches')).toBeInTheDocument();

--- a/frontend/src/pages/Matches.jsx
+++ b/frontend/src/pages/Matches.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { matches as matchesApi } from '../services/api.js';
@@ -17,14 +17,12 @@ const PAGE_SIZE = 15;
 
 const STATUS_TABS = [
   { value: '', label: 'All' },
-  { value: 'pending', label: 'Pending' },
   { value: 'proposed', label: 'Proposed' },
   { value: 'accepted', label: 'Accepted' },
   { value: 'declined', label: 'Declined' },
 ];
 
 const STATUS_CONFIG = {
-  pending: { label: 'Pending', cls: 'badge-amber' },
   proposed: { label: 'Proposed', cls: 'badge-amber' },
   accepted: { label: 'Accepted', cls: 'badge-green' },
   declined: { label: 'Declined', cls: 'badge-red' },
@@ -35,10 +33,11 @@ export default function Matches() {
   const { user } = useAuth();
   const queryClient = useQueryClient();
   const [page, setPage] = useState(1);
-  const [statusFilter, setStatusFilter] = useState('pending');
+  const [statusFilter, setStatusFilter] = useState('proposed');
   const [actionError, setActionError] = useState(null);
   const [requiresAddressVerification, setRequiresAddressVerification] = useState(false);
   const [verificationUrl, setVerificationUrl] = useState('/account');
+  const isInitialLoad = useRef(true);
 
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['matches', statusFilter, page],
@@ -48,6 +47,18 @@ export default function Matches() {
       return matchesApi.list(params).then((r) => r.data);
     },
   });
+
+  // On first load, if there are no proposed matches fall back to the All tab.
+  useEffect(() => {
+    if (!isInitialLoad.current) return;
+    if (isLoading) return;
+    if (statusFilter !== 'proposed') { isInitialLoad.current = false; return; }
+    const { count } = parsePaginatedResponse(data);
+    if (count === 0) {
+      setStatusFilter('');
+    }
+    isInitialLoad.current = false;
+  }, [isLoading, data, statusFilter]);
 
   const acceptMutation = useMutation({
     mutationFn: (id) => matchesApi.accept(id),
@@ -88,6 +99,7 @@ export default function Matches() {
   const totalPages = Math.ceil(count / PAGE_SIZE);
 
   function handleTabChange(val) {
+    isInitialLoad.current = false;
     setStatusFilter(val);
     setPage(1);
   }
@@ -136,7 +148,7 @@ export default function Matches() {
       ) : items.length === 0 ? (
         <div className={styles.empty}>
           <p className={styles.emptyTitle}>
-            {statusFilter === 'pending' ? 'No pending matches' : 'No matches found'}
+            {statusFilter === 'proposed' ? 'No proposed matches' : 'No matches found'}
           </p>
           <p className={styles.emptySubtitle}>
             Matches are created automatically when your books line up with other users&apos; wishlists.
@@ -172,17 +184,15 @@ function MatchCard({ match, currentUserId, onAccept, onDecline, accepting, decli
   const theirBook = match.theirBook;
   const partner = match.partner;
 
-  const isPending = match.status === 'pending' || match.status === 'proposed';
+  const isProposed = match.status === 'proposed';
   const hasAccepted = match.legs?.find(leg => String(leg.sender?.id) === String(currentUserId))?.status === 'accepted';
 
   return (
     <div className={`card ${styles.matchCard}`}>
       <div className={styles.matchHeader}>
         <div className={styles.matchId}>Match #{match.id}</div>
-        {(match.status === 'pending' || match.status === 'proposed') ? (
-          <Tooltip content={match.status === 'pending' 
-            ? "This match was found automatically. It's waiting for initial processing." 
-            : "This match has been proposed. It's waiting for both of you to accept."}>
+        {match.status === 'proposed' ? (
+          <Tooltip content="This match is waiting for both of you to accept.">
             <span className={`badge ${statusConfig.cls}`}>{statusConfig.label}</span>
           </Tooltip>
         ) : match.status === 'expired' ? (
@@ -266,7 +276,7 @@ function MatchCard({ match, currentUserId, onAccept, onDecline, accepting, decli
         </p>
       )}
 
-      {isPending && (
+      {isProposed && (
         <div className={styles.matchActions}>
           {hasAccepted ? (
             <span className="badge badge-gray">Waiting for partner...</span>

--- a/frontend/src/pages/Matches.jsx
+++ b/frontend/src/pages/Matches.jsx
@@ -52,13 +52,14 @@ export default function Matches() {
   useEffect(() => {
     if (!isInitialLoad.current) return;
     if (isLoading) return;
+    if (isError) { isInitialLoad.current = false; return; }
     if (statusFilter !== 'proposed') { isInitialLoad.current = false; return; }
     const { count } = parsePaginatedResponse(data);
     if (count === 0) {
       setStatusFilter('');
     }
     isInitialLoad.current = false;
-  }, [isLoading, data, statusFilter]);
+  }, [isLoading, isError, data, statusFilter]);
 
   const acceptMutation = useMutation({
     mutationFn: (id) => matchesApi.accept(id),

--- a/frontend/src/pages/Matches.test.jsx
+++ b/frontend/src/pages/Matches.test.jsx
@@ -32,7 +32,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-1',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             {
@@ -91,7 +91,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-1',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             {
@@ -141,18 +141,18 @@ describe('Matches page', () => {
     it('shows empty state when no matches found (all tab)', async () => {
         matches.list.mockResolvedValue({ data: { count: 0, results: [] } });
         renderWithProviders(<Matches />);
-        // Default tab is 'pending', switch to 'all' to see "no matches found"
+        // Switch to All tab to see "no matches found"
         const allTab = await screen.findByRole('button', { name: /^all$/i });
         await userEvent.click(allTab);
         expect(await screen.findByText(/no matches found/i)).toBeInTheDocument();
     });
 
-    it('shows "No pending matches" when pending tab active and empty', async () => {
+    it('shows "No proposed matches" when proposed tab active and empty', async () => {
         matches.list.mockResolvedValue({ data: { count: 0, results: [] } });
         renderWithProviders(<Matches />);
-        const pendingTab = await screen.findByRole('button', { name: /^pending$/i });
-        await userEvent.click(pendingTab);
-        expect(await screen.findByText(/no pending matches/i)).toBeInTheDocument();
+        const proposedTab = await screen.findByRole('button', { name: /^proposed$/i });
+        await userEvent.click(proposedTab);
+        expect(await screen.findByText(/no proposed matches/i)).toBeInTheDocument();
     });
 
     it('shows "Book info unavailable" for match leg with no book data', async () => {
@@ -162,7 +162,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-2',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             {
@@ -192,7 +192,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-9',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             { sender: { id: 'user-1', username: 'bart0605' }, receiver: { id: 'user-2', username: 'alice' }, user_book: { condition: 'good', book: { id: 'b13', title: 'Book G', authors: ['Author'] } } },
@@ -216,7 +216,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-10',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             { sender: { id: 'user-1', username: 'bart0605' }, receiver: { id: 'user-2', username: 'alice' }, user_book: { condition: 'good', book: { id: 'b15', title: 'Book I', authors: ['Author'] } } },
@@ -249,7 +249,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-4',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             { sender: { id: 'user-1', username: 'bart0605' }, receiver: { id: 'user-2', username: 'alice' }, user_book: { condition: 'good', book: { id: 'b1', title: 'Book A', authors: ['Author'] } } },
@@ -272,7 +272,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-5',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             { sender: { id: 'user-1', username: 'bart0605' }, receiver: { id: 'user-2', username: 'alice' }, user_book: { condition: 'good', book: { id: 'b3', title: 'Book C', authors: ['Author'] } } },
@@ -295,7 +295,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-6',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             { sender: { id: 'user-1', username: 'bart0605' }, receiver: { id: 'user-2', username: 'alice' }, user_book: { condition: 'good', book: { id: 'b5', title: 'Book E', authors: ['Author'] } } },
@@ -365,7 +365,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-8',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             { sender: { id: 'user-1', username: 'bart0605' }, receiver: { id: 'user-2', username: 'alice' }, user_book: { condition: 'good', book: { id: 'b11', title: 'Clear Error Book A', authors: ['Author'] } } },
@@ -399,7 +399,7 @@ describe('Matches page', () => {
                 results: [
                     {
                         id: 'match-3',
-                        status: 'pending',
+                        status: 'proposed',
                         match_type: 'direct',
                         legs: [
                             {


### PR DESCRIPTION
## Summary

- `Match.Status.PENDING` was dead code — the matching engine always created matches as `PROPOSED` and both statuses were treated identically in every query. This removes the ambiguity entirely.
- Adds a data migration (`0002`) that converts any existing `pending` rows to `proposed` before dropping the choice.
- Removes the `status=pending` filter branch from `MatchListView` (no frontend tab was calling it after this change).
- Frontend: replaces the **Pending** tab with **Proposed** as the primary/default tab. On first load, if there are no proposed matches, the page automatically falls back to the **All** tab.
- `Dashboard.jsx` updated to fetch active matches with `status=proposed`.
- All tests, factories, seed commands, and documentation updated throughout.

## Test plan

- [ ] Existing proposed matches visible in the Proposed tab
- [ ] User with no proposed matches lands on the All tab automatically
- [ ] "Waiting for partner…" still shown correctly when one party has accepted but the other hasn't (match stays in Proposed)
- [ ] Accepted tab only shows fully completed matches
- [ ] `pytest apps/matching/` — all matching tests pass
- [ ] `npm run test:run` in `frontend/` — all frontend tests pass
- [ ] `python manage.py migrate` applies `0002` cleanly with no errors

https://claude.ai/code/session_013QfKFYHp6ufWWYaVseKvqX

---
_Generated by [Claude Code](https://claude.ai/code/session_013QfKFYHp6ufWWYaVseKvqX)_