### PR TITLE
Fix accepted match handoff to trade shipping flow

### DIFF
--- a/apps/matching/serializers.py
+++ b/apps/matching/serializers.py
@@ -44,6 +44,16 @@ class MatchSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_trade_id(self, obj):
+        # Only COMPLETED matches have an associated trade.
+        if obj.status != Match.Status.COMPLETED:
+            return None
+
+        # Use preloaded mapping from context when available (avoids N+1 on list).
+        trade_ids = self.context.get("trade_ids")
+        if trade_ids is not None:
+            return str(trade_id) if (trade_id := trade_ids.get(obj.id)) else None
+
+        # Fallback: single DB query (used for detail / accept views).
         from apps.trading.models import Trade
 
         trade_id = (

--- a/apps/matching/serializers.py
+++ b/apps/matching/serializers.py
@@ -15,8 +15,12 @@ class MatchLegSerializer(serializers.ModelSerializer):
     class Meta:
         model = MatchLeg
         fields = [
-            'id', 'sender', 'receiver', 'user_book',
-            'position', 'status',
+            "id",
+            "sender",
+            "receiver",
+            "user_book",
+            "position",
+            "status",
         ]
         read_only_fields = fields
 
@@ -28,8 +32,14 @@ class MatchSerializer(serializers.ModelSerializer):
     class Meta:
         model = Match
         fields = [
-            'id', 'match_type', 'status', 'detected_at',
-            'expires_at', 'updated_at', 'legs', 'trade_id',
+            "id",
+            "match_type",
+            "status",
+            "detected_at",
+            "expires_at",
+            "updated_at",
+            "legs",
+            "trade_id",
         ]
         read_only_fields = fields
 
@@ -41,7 +51,7 @@ class MatchSerializer(serializers.ModelSerializer):
                 source_type=Trade.SourceType.MATCH,
                 source_id=obj.id,
             )
-            .values_list('id', flat=True)
+            .values_list("id", flat=True)
             .first()
         )
         return str(trade_id) if trade_id else None

--- a/apps/matching/serializers.py
+++ b/apps/matching/serializers.py
@@ -48,10 +48,12 @@ class MatchSerializer(serializers.ModelSerializer):
         if obj.status != Match.Status.COMPLETED:
             return None
 
-        # Use preloaded mapping from context when available (avoids N+1 on list).
-        trade_ids = self.context.get("trade_ids")
-        if trade_ids is not None:
-            return str(trade_id) if (trade_id := trade_ids.get(obj.id)) else None
+        # Use annotated _trade_id from the list view queryset (avoids N+1).
+        # Fall back to a direct DB query for the detail / accept views where
+        # the annotation is not present.
+        trade_id = getattr(obj, "_trade_id", None)
+        if trade_id is not None:
+            return str(trade_id)
 
         # Fallback: single DB query (used for detail / accept views).
         from apps.trading.models import Trade

--- a/apps/matching/serializers.py
+++ b/apps/matching/serializers.py
@@ -23,14 +23,28 @@ class MatchLegSerializer(serializers.ModelSerializer):
 
 class MatchSerializer(serializers.ModelSerializer):
     legs = MatchLegSerializer(many=True, read_only=True)
+    trade_id = serializers.SerializerMethodField()
 
     class Meta:
         model = Match
         fields = [
             'id', 'match_type', 'status', 'detected_at',
-            'expires_at', 'updated_at', 'legs',
+            'expires_at', 'updated_at', 'legs', 'trade_id',
         ]
         read_only_fields = fields
+
+    def get_trade_id(self, obj):
+        from apps.trading.models import Trade
+
+        trade_id = (
+            Trade.objects.filter(
+                source_type=Trade.SourceType.MATCH,
+                source_id=obj.id,
+            )
+            .values_list('id', flat=True)
+            .first()
+        )
+        return str(trade_id) if trade_id else None
 
 
 class DiscoveryPartnerSerializer(serializers.Serializer):

--- a/apps/matching/tests/test_match_views.py
+++ b/apps/matching/tests/test_match_views.py
@@ -3,9 +3,16 @@ from django.urls import reverse
 from rest_framework import status
 from unittest.mock import patch
 
-from apps.tests.factories import UserFactory, BookFactory, UserBookFactory, MatchFactory, MatchLegFactory
+from apps.tests.factories import (
+    UserFactory,
+    BookFactory,
+    UserBookFactory,
+    MatchFactory,
+    MatchLegFactory,
+)
 from apps.matching.models import Match, MatchLeg
 from apps.trading.models import Trade
+
 
 @pytest.mark.django_db
 class TestMatchViews:
@@ -22,21 +29,33 @@ class TestMatchViews:
         m2 = MatchFactory()
         MatchLegFactory(match=m2, sender=other, receiver=user)
 
-        url = reverse('match-list')
+        url = reverse("match-list")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data) == 2
 
-    def test_match_list_status_filter_accepted_shows_completed_matches(self, api_client):
+    def test_match_list_status_filter_accepted_shows_completed_matches(
+        self, api_client
+    ):
         """Completed matches (both legs accepted) must appear under status=accepted."""
         user = UserFactory()
         other = UserFactory()
         api_client.force_authenticate(user=user)
 
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
-        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
-        MatchLegFactory(match=completed_match, sender=other, receiver=user, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(
+            match=completed_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.ACCEPTED,
+        )
+        MatchLegFactory(
+            match=completed_match,
+            sender=other,
+            receiver=user,
+            status=MatchLeg.Status.ACCEPTED,
+        )
         trade = Trade.objects.create(
             source_type=Trade.SourceType.MATCH,
             source_id=completed_match.id,
@@ -44,46 +63,79 @@ class TestMatchViews:
         )
 
         proposed_match = MatchFactory(status=Match.Status.PROPOSED)
-        MatchLegFactory(match=proposed_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
+        MatchLegFactory(
+            match=proposed_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.PENDING,
+        )
 
-        url = reverse('match-list')
-        response = api_client.get(url, {'status': 'accepted'})
+        url = reverse("match-list")
+        response = api_client.get(url, {"status": "accepted"})
 
         assert response.status_code == status.HTTP_200_OK
-        returned_ids = {item['id'] for item in response.data}
+        returned_ids = {item["id"] for item in response.data}
         assert str(completed_match.id) in returned_ids
         assert str(proposed_match.id) not in returned_ids
-        completed_payload = next(item for item in response.data if item['id'] == str(completed_match.id))
-        assert completed_payload['trade_id'] == str(trade.id)
+        completed_payload = next(
+            item for item in response.data if item["id"] == str(completed_match.id)
+        )
+        assert completed_payload["trade_id"] == str(trade.id)
 
-    def test_match_list_status_filter_proposed_includes_waiting_for_partner(self, api_client):
+    def test_match_list_status_filter_proposed_includes_waiting_for_partner(
+        self, api_client
+    ):
         """A match stays in proposed for a user who has already accepted until ALL parties accept."""
         user = UserFactory()
         other = UserFactory()
         api_client.force_authenticate(user=user)
 
         proposed_match = MatchFactory(status=Match.Status.PROPOSED)
-        MatchLegFactory(match=proposed_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
+        MatchLegFactory(
+            match=proposed_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.PENDING,
+        )
 
         # User already accepted their sender leg; match is still PROPOSED waiting for the other party.
         # This must still appear in the proposed tab — not the accepted tab.
         waiting_match = MatchFactory(status=Match.Status.PROPOSED)
-        MatchLegFactory(match=waiting_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
-        MatchLegFactory(match=waiting_match, sender=other, receiver=user, status=MatchLeg.Status.PENDING)
+        MatchLegFactory(
+            match=waiting_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.ACCEPTED,
+        )
+        MatchLegFactory(
+            match=waiting_match,
+            sender=other,
+            receiver=user,
+            status=MatchLeg.Status.PENDING,
+        )
 
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
-        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(
+            match=completed_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.ACCEPTED,
+        )
 
-        url = reverse('match-list')
-        response = api_client.get(url, {'status': 'proposed'})
+        url = reverse("match-list")
+        response = api_client.get(url, {"status": "proposed"})
 
         assert response.status_code == status.HTTP_200_OK
-        returned_ids = {item['id'] for item in response.data}
+        returned_ids = {item["id"] for item in response.data}
         assert str(proposed_match.id) in returned_ids
-        assert str(waiting_match.id) in returned_ids  # must stay proposed until partner also accepts
+        assert (
+            str(waiting_match.id) in returned_ids
+        )  # must stay proposed until partner also accepts
         assert str(completed_match.id) not in returned_ids
 
-    def test_match_list_status_filter_accepted_excludes_waiting_for_partner(self, api_client):
+    def test_match_list_status_filter_accepted_excludes_waiting_for_partner(
+        self, api_client
+    ):
         """A match where the user accepted but the partner hasn't must NOT appear under status=accepted."""
         user = UserFactory()
         other = UserFactory()
@@ -91,18 +143,38 @@ class TestMatchViews:
 
         # User accepted their leg but the overall match is still PROPOSED (partner hasn't responded).
         waiting_match = MatchFactory(status=Match.Status.PROPOSED)
-        MatchLegFactory(match=waiting_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
-        MatchLegFactory(match=waiting_match, sender=other, receiver=user, status=MatchLeg.Status.PENDING)
+        MatchLegFactory(
+            match=waiting_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.ACCEPTED,
+        )
+        MatchLegFactory(
+            match=waiting_match,
+            sender=other,
+            receiver=user,
+            status=MatchLeg.Status.PENDING,
+        )
 
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
-        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
-        MatchLegFactory(match=completed_match, sender=other, receiver=user, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(
+            match=completed_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.ACCEPTED,
+        )
+        MatchLegFactory(
+            match=completed_match,
+            sender=other,
+            receiver=user,
+            status=MatchLeg.Status.ACCEPTED,
+        )
 
-        url = reverse('match-list')
-        response = api_client.get(url, {'status': 'accepted'})
+        url = reverse("match-list")
+        response = api_client.get(url, {"status": "accepted"})
 
         assert response.status_code == status.HTTP_200_OK
-        returned_ids = {item['id'] for item in response.data}
+        returned_ids = {item["id"] for item in response.data}
         assert str(completed_match.id) in returned_ids
         assert str(waiting_match.id) not in returned_ids
 
@@ -114,17 +186,32 @@ class TestMatchViews:
 
         # User accepted but the match expired because someone else declined.
         expired_match = MatchFactory(status=Match.Status.EXPIRED)
-        MatchLegFactory(match=expired_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
-        MatchLegFactory(match=expired_match, sender=other, receiver=user, status=MatchLeg.Status.DECLINED)
+        MatchLegFactory(
+            match=expired_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.ACCEPTED,
+        )
+        MatchLegFactory(
+            match=expired_match,
+            sender=other,
+            receiver=user,
+            status=MatchLeg.Status.DECLINED,
+        )
 
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
-        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(
+            match=completed_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.ACCEPTED,
+        )
 
-        url = reverse('match-list')
-        response = api_client.get(url, {'status': 'accepted'})
+        url = reverse("match-list")
+        response = api_client.get(url, {"status": "accepted"})
 
         assert response.status_code == status.HTTP_200_OK
-        returned_ids = {item['id'] for item in response.data}
+        returned_ids = {item["id"] for item in response.data}
         assert str(completed_match.id) in returned_ids
         assert str(expired_match.id) not in returned_ids
 
@@ -138,13 +225,18 @@ class TestMatchViews:
         MatchLegFactory(match=proposed_match, sender=user, receiver=other)
 
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
-        MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
+        MatchLegFactory(
+            match=completed_match,
+            sender=user,
+            receiver=other,
+            status=MatchLeg.Status.ACCEPTED,
+        )
 
-        url = reverse('match-list')
+        url = reverse("match-list")
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        returned_ids = {item['id'] for item in response.data}
+        returned_ids = {item["id"] for item in response.data}
         assert str(proposed_match.id) in returned_ids
         assert str(completed_match.id) in returned_ids
 
@@ -156,11 +248,11 @@ class TestMatchViews:
         match = MatchFactory()
         MatchLegFactory(match=match, sender=user, receiver=other)
 
-        url = reverse('match-detail', kwargs={'pk': match.pk})
+        url = reverse("match-detail", kwargs={"pk": match.pk})
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.data['id'] == str(match.id)
+        assert response.data["id"] == str(match.id)
 
     def test_match_detail_not_participant(self, api_client):
         user = UserFactory()
@@ -169,7 +261,7 @@ class TestMatchViews:
         match = MatchFactory()
         MatchLegFactory(match=match, sender=UserFactory(), receiver=UserFactory())
 
-        url = reverse('match-detail', kwargs={'pk': match.pk})
+        url = reverse("match-detail", kwargs={"pk": match.pk})
         response = api_client.get(url)
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
@@ -185,7 +277,7 @@ class TestMatchViews:
         leg_a = MatchLegFactory(match=match, sender=user_a, receiver=user_b)
         leg_b = MatchLegFactory(match=match, sender=user_b, receiver=user_a)
 
-        url = reverse('match-accept', kwargs={'pk': match.pk})
+        url = reverse("match-accept", kwargs={"pk": match.pk})
 
         # User A accepts
         api_client.force_authenticate(user=user_a)
@@ -205,17 +297,17 @@ class TestMatchViews:
         assert mock_create_trade.called
 
     def test_match_accept_no_address(self, api_client):
-        user = UserFactory(address_verification_status='unverified')
+        user = UserFactory(address_verification_status="unverified")
         api_client.force_authenticate(user=user)
 
         match = MatchFactory()
         MatchLegFactory(match=match, sender=user, receiver=UserFactory())
 
-        url = reverse('match-accept', kwargs={'pk': match.pk})
+        url = reverse("match-accept", kwargs={"pk": match.pk})
         response = api_client.post(url)
 
         assert response.status_code == status.HTTP_409_CONFLICT
-        assert response.data['code'] == 'address_verification_required'
+        assert response.data["code"] == "address_verification_required"
 
     def test_match_decline(self, api_client):
         user = UserFactory()
@@ -224,7 +316,7 @@ class TestMatchViews:
         match = MatchFactory(match_type=Match.MatchType.DIRECT)
         leg = MatchLegFactory(match=match, sender=user, receiver=UserFactory())
 
-        url = reverse('match-decline', kwargs={'pk': match.pk})
+        url = reverse("match-decline", kwargs={"pk": match.pk})
         response = api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK
@@ -241,7 +333,7 @@ class TestMatchViews:
         match = MatchFactory(match_type=Match.MatchType.RING)
         MatchLegFactory(match=match, sender=user, receiver=UserFactory())
 
-        url = reverse('match-decline', kwargs={'pk': match.pk})
+        url = reverse("match-decline", kwargs={"pk": match.pk})
         response = api_client.post(url)
 
         assert response.status_code == status.HTTP_200_OK

--- a/apps/matching/tests/test_match_views.py
+++ b/apps/matching/tests/test_match_views.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from apps.tests.factories import UserFactory, BookFactory, UserBookFactory, MatchFactory, MatchLegFactory
 from apps.matching.models import Match, MatchLeg
+from apps.trading.models import Trade
 
 @pytest.mark.django_db
 class TestMatchViews:
@@ -36,6 +37,11 @@ class TestMatchViews:
         completed_match = MatchFactory(status=Match.Status.COMPLETED)
         MatchLegFactory(match=completed_match, sender=user, receiver=other, status=MatchLeg.Status.ACCEPTED)
         MatchLegFactory(match=completed_match, sender=other, receiver=user, status=MatchLeg.Status.ACCEPTED)
+        trade = Trade.objects.create(
+            source_type=Trade.SourceType.MATCH,
+            source_id=completed_match.id,
+            status=Trade.Status.CONFIRMED,
+        )
 
         proposed_match = MatchFactory(status=Match.Status.PROPOSED)
         MatchLegFactory(match=proposed_match, sender=user, receiver=other, status=MatchLeg.Status.PENDING)
@@ -47,6 +53,8 @@ class TestMatchViews:
         returned_ids = {item['id'] for item in response.data}
         assert str(completed_match.id) in returned_ids
         assert str(proposed_match.id) not in returned_ids
+        completed_payload = next(item for item in response.data if item['id'] == str(completed_match.id))
+        assert completed_payload['trade_id'] == str(trade.id)
 
     def test_match_list_status_filter_proposed_includes_waiting_for_partner(self, api_client):
         """A match stays in proposed for a user who has already accepted until ALL parties accept."""

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -1,7 +1,7 @@
 import logging
-import uuid
 
 from django.db import transaction
+from django.db.models import OuterRef, Subquery
 from django.utils import timezone
 from rest_framework import permissions, status
 from rest_framework.response import Response
@@ -64,28 +64,23 @@ class MatchListView(APIView):
                 )
             )
 
-        match_list = list(
+        from apps.trading.models import Trade
+
+        matches = (
             Match.objects.filter(id__in=match_ids)
+            .annotate(
+                _trade_id=Subquery(
+                    Trade.objects.filter(
+                        source_type=Trade.SourceType.MATCH,
+                        source_id=OuterRef("id"),
+                    ).values("id")[:1]
+                )
+            )
             .prefetch_related("legs__sender", "legs__receiver", "legs__user_book__book")
             .order_by("-detected_at")
         )
 
-        # Preload trade IDs for COMPLETED matches in a single query to avoid N+1.
-        from apps.trading.models import Trade
-
-        completed_ids = [m.id for m in match_list if m.status == Match.Status.COMPLETED]
-        trade_id_map: dict[uuid.UUID, uuid.UUID] = {}
-        if completed_ids:
-            trade_id_map = dict(
-                Trade.objects.filter(
-                    source_type=Trade.SourceType.MATCH,
-                    source_id__in=completed_ids,
-                ).values_list("source_id", "id")
-            )
-
-        return Response(
-            MatchSerializer(match_list, many=True, context={"trade_ids": trade_id_map}).data
-        )
+        return Response(MatchSerializer(matches, many=True).data)
 
 
 class MatchDetailView(APIView):

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -1,4 +1,5 @@
 import logging
+import uuid
 
 from django.db import transaction
 from django.utils import timezone
@@ -63,12 +64,28 @@ class MatchListView(APIView):
                 )
             )
 
-        matches = (
+        match_list = list(
             Match.objects.filter(id__in=match_ids)
             .prefetch_related("legs__sender", "legs__receiver", "legs__user_book__book")
             .order_by("-detected_at")
         )
-        return Response(MatchSerializer(matches, many=True).data)
+
+        # Preload trade IDs for COMPLETED matches in a single query to avoid N+1.
+        from apps.trading.models import Trade
+
+        completed_ids = [m.id for m in match_list if m.status == Match.Status.COMPLETED]
+        trade_id_map: dict[uuid.UUID, uuid.UUID] = {}
+        if completed_ids:
+            trade_id_map = dict(
+                Trade.objects.filter(
+                    source_type=Trade.SourceType.MATCH,
+                    source_id__in=completed_ids,
+                ).values_list("source_id", "id")
+            )
+
+        return Response(
+            MatchSerializer(match_list, many=True, context={"trade_ids": trade_id_map}).data
+        )
 
 
 class MatchDetailView(APIView):

--- a/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
+++ b/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
@@ -17,13 +17,11 @@
  *  6.  Alice  Sees the proposed match, accepts it; match moves to Accepted tab.
  *  7.  Bob    Sees the proposed match, accepts it; match becomes COMPLETED.
  *  8.  Both   Match visible in Accepted tab.
- *  9.  Alice  Sees confirmed trade in Trades list.
- * 10.  Bob    Sees confirmed trade in Trades list.
- * 11.  Alice  Opens trade detail, enters tracking number, marks shipped.
- * 12.  Bob    Opens trade detail, enters tracking number, marks shipped.
- * 13.  Alice  Marks her received book.
- * 14.  Bob    Marks his received book → trade status becomes Completed.
- * 15.  Alice  Completed trade visible in Completed tab.
+ *  9.  Alice  Opens trade from Accepted match card and marks shipped.
+ * 10.  Bob    Opens trade from Accepted match card and marks shipped.
+ * 11.  Alice  Marks her received book.
+ * 12.  Bob    Marks his received book → trade status becomes Completed.
+ * 13.  Alice  Completed trade visible in Completed tab.
  *
  * Books
  * ─────
@@ -115,15 +113,16 @@ async function uiAddWishlist(page, bookData) {
   await isbnInput.fill(bookData.isbn_13);
   await page.getByRole('button', { name: /look\s*up/i }).click();
 
-  // Edition preference modal appears automatically after lookup — dismiss it
-  // before asserting on the book title to avoid strict-mode violations (the
-  // overlay also contains the title in a <strong> tag alongside the preview).
-  const doneBtn = page.getByRole('button', { name: /^done$/i });
-  if (await doneBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
-    await doneBtn.click();
-  }
-
   await expect(page.getByText(bookData.title).first()).toBeVisible({ timeout: 8_000 });
+
+  // Edition preference can appear slightly after lookup; close it right before
+  // submitting so the overlay cannot intercept the final click.
+  const overlay = page.locator('[data-testid="edition-preference-overlay"]');
+  const doneBtn = page.getByRole('button', { name: /^done$/i });
+  if (await overlay.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await doneBtn.click();
+    await expect(overlay).toBeHidden({ timeout: 5_000 });
+  }
 
   await page.getByRole('button', { name: /add to wishlist/i }).last().click();
 
@@ -134,12 +133,17 @@ async function uiAddWishlist(page, bookData) {
   await expect(page.getByText(bookData.title)).toBeVisible({ timeout: 5_000 });
 }
 
-// ── Helper: open the trade involving a given book title and navigate to detail ─
+// ── Helper: open a trade from Matches > Accepted via card action ─────────────
 
-async function openTradeDetail(page, bookTitle) {
-  await page.goto('/trades');
+async function openTradeFromAcceptedMatch(page, bookTitle) {
+  await page.goto('/matches');
+  await page.getByRole('button', { name: /^accepted$/i }).click();
   await page.waitForLoadState('networkidle');
-  await page.locator('[class*="tradeCard"]').filter({ hasText: bookTitle }).click();
+
+  const card = page.locator('[class*="matchCard"]').filter({ hasText: bookTitle });
+  await expect(card).toBeVisible({ timeout: 10_000 });
+  await card.getByRole('link', { name: /open trade/i }).click();
+
   await expect(page).toHaveURL(/\/trades\/.+/);
   await expect(page.getByText(/trade #/i)).toBeVisible({ timeout: 8_000 });
 }
@@ -256,30 +260,10 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     ).toBeVisible({ timeout: 10_000 });
   });
 
-  // ── Steps 9–10: Trade list ────────────────────────────────────────────────
-
-  test('confirmed trade appears in alice trades list', async ({ alicePage: page }) => {
-    await page.goto('/trades');
-    await page.waitForLoadState('networkidle');
-
-    const tradeCard = page.locator('[class*="tradeCard"]').filter({ hasText: ALICE_SENDS });
-    await expect(tradeCard).toBeVisible({ timeout: 10_000 });
-    await expect(tradeCard.getByText(/confirmed/i)).toBeVisible();
-  });
-
-  test('confirmed trade appears in bob trades list', async ({ bobPage: page }) => {
-    await page.goto('/trades');
-    await page.waitForLoadState('networkidle');
-
-    const tradeCard = page.locator('[class*="tradeCard"]').filter({ hasText: BOB_SENDS });
-    await expect(tradeCard).toBeVisible({ timeout: 10_000 });
-    await expect(tradeCard.getByText(/confirmed/i)).toBeVisible();
-  });
-
-  // ── Step 11: Alice marks her book shipped ─────────────────────────────────
+  // ── Step 9: Alice opens trade from accepted match and marks shipped ───────
 
   test('alice opens trade detail and marks her book shipped', async ({ alicePage: page }) => {
-    await openTradeDetail(page, ALICE_SENDS);
+    await openTradeFromAcceptedMatch(page, ALICE_SENDS);
 
     const shipBtn = page.getByRole('button', { name: /mark my book as shipped/i });
     await expect(shipBtn).toBeVisible({ timeout: 8_000 });
@@ -296,10 +280,10 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     ).toBeVisible({ timeout: 12_000 });
   });
 
-  // ── Step 12: Bob marks his book shipped ──────────────────────────────────
+  // ── Step 10: Bob opens trade from accepted match and marks shipped ───────
 
   test('bob opens trade detail and marks his book shipped', async ({ bobPage: page }) => {
-    await openTradeDetail(page, BOB_SENDS);
+    await openTradeFromAcceptedMatch(page, BOB_SENDS);
 
     const shipBtn = page.getByRole('button', { name: /mark my book as shipped/i });
     await expect(shipBtn).toBeVisible({ timeout: 8_000 });
@@ -316,10 +300,10 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     ).toBeVisible({ timeout: 12_000 });
   });
 
-  // ── Step 13: Alice marks book received ───────────────────────────────────
+  // ── Step 11: Alice marks book received ────────────────────────────────────
 
   test('alice marks her received book', async ({ alicePage: page }) => {
-    await openTradeDetail(page, ALICE_SENDS);
+    await openTradeFromAcceptedMatch(page, ALICE_SENDS);
 
     autoConfirmDialog(page);
     const receiveBtn = page.getByRole('button', { name: /mark book received/i });
@@ -331,10 +315,10 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     ).toBeVisible({ timeout: 12_000 });
   });
 
-  // ── Step 14: Bob marks book received → trade completes ───────────────────
+  // ── Step 12: Bob marks book received → trade completes ────────────────────
 
   test('bob marks his received book and the trade completes', async ({ bobPage: page }) => {
-    await openTradeDetail(page, BOB_SENDS);
+    await openTradeFromAcceptedMatch(page, BOB_SENDS);
 
     autoConfirmDialog(page);
     const receiveBtn = page.getByRole('button', { name: /mark book received/i });
@@ -346,7 +330,7 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     ).toBeVisible({ timeout: 12_000 });
   });
 
-  // ── Step 15: Completed tab ────────────────────────────────────────────────
+  // ── Step 13: Completed tab ─────────────────────────────────────────────────
 
   test('completed trade appears in alice completed tab', async ({ alicePage: page }) => {
     await page.goto('/trades');

--- a/frontend/src/adapters/matches.js
+++ b/frontend/src/adapters/matches.js
@@ -24,6 +24,7 @@ export function mapMatchForCard(match, currentUserId) {
 
   return {
     ...match,
+    tradeId: match?.trade_id ?? null,
     yourBook,
     yourCondition: outgoingLeg?.user_book?.condition ?? match?.your_book?.condition ?? null,
     theirBook,

--- a/frontend/src/pages/Matches.jsx
+++ b/frontend/src/pages/Matches.jsx
@@ -305,9 +305,9 @@ function MatchCard({ match, currentUserId, onAccept, onDecline, accepting, decli
         </div>
       )}
 
-      {!isProposed && (
+      {match.tradeId && (
         <div className={styles.matchActions}>
-          <Link className="btn btn-primary" to={match.tradeId ? `/trades/${match.tradeId}` : '/trades'}>
+          <Link className="btn btn-primary" to={`/trades/${match.tradeId}`}>
             Open Trade
           </Link>
         </div>

--- a/frontend/src/pages/Matches.jsx
+++ b/frontend/src/pages/Matches.jsx
@@ -25,6 +25,7 @@ const STATUS_TABS = [
 const STATUS_CONFIG = {
   proposed: { label: 'Proposed', cls: 'badge-amber' },
   accepted: { label: 'Accepted', cls: 'badge-green' },
+  completed: { label: 'Waiting for shipping details', cls: 'badge-blue' },
   declined: { label: 'Declined', cls: 'badge-red' },
   expired: { label: 'Expired', cls: 'badge-gray' },
 };
@@ -301,6 +302,14 @@ function MatchCard({ match, currentUserId, onAccept, onDecline, accepting, decli
               </button>
             </>
           )}
+        </div>
+      )}
+
+      {!isProposed && (
+        <div className={styles.matchActions}>
+          <Link className="btn btn-primary" to={match.tradeId ? `/trades/${match.tradeId}` : '/trades'}>
+            Open Trade
+          </Link>
         </div>
       )}
     </div>

--- a/frontend/src/pages/Matches.jsx
+++ b/frontend/src/pages/Matches.jsx
@@ -25,7 +25,7 @@ const STATUS_TABS = [
 const STATUS_CONFIG = {
   proposed: { label: 'Proposed', cls: 'badge-amber' },
   accepted: { label: 'Accepted', cls: 'badge-green' },
-  completed: { label: 'Waiting for shipping details', cls: 'badge-blue' },
+  completed: { label: 'Trade Confirmed', cls: 'badge-blue' },
   declined: { label: 'Declined', cls: 'badge-red' },
   expired: { label: 'Expired', cls: 'badge-gray' },
 };

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -210,26 +210,24 @@ export default function TradeDetail() {
           </div>
 
           {/* Shipping address */}
-          {(tradeView.status !== 'confirmed') && (
-            <div className={`card ${styles.section}`}>
-              <h2 className={styles.sectionTitle}>Shipping Address</h2>
-              {tradeView.partnerAddress ? (
-                <div className={styles.address}>
-                  <p>{tradeView.partnerAddress.name}</p>
-                  <p>{tradeView.partnerAddress.street}</p>
-                  {tradeView.partnerAddress.street2 && <p>{tradeView.partnerAddress.street2}</p>}
-                  <p>
-                    {tradeView.partnerAddress.city}, {tradeView.partnerAddress.state}{' '}
-                    {tradeView.partnerAddress.zip}
-                  </p>
-                </div>
-              ) : (
-                <p className={styles.addressHidden}>
-                  Address will be revealed when both parties confirm shipping.
+          <div className={`card ${styles.section}`}>
+            <h2 className={styles.sectionTitle}>Shipping Address</h2>
+            {tradeView.partnerAddress ? (
+              <div className={styles.address}>
+                <p>{tradeView.partnerAddress.name}</p>
+                <p>{tradeView.partnerAddress.street}</p>
+                {tradeView.partnerAddress.street2 && <p>{tradeView.partnerAddress.street2}</p>}
+                <p>
+                  {tradeView.partnerAddress.city}, {tradeView.partnerAddress.state}{' '}
+                  {tradeView.partnerAddress.zip}
                 </p>
-              )}
-            </div>
-          )}
+              </div>
+            ) : (
+              <p className={styles.addressHidden}>
+                Shipping address is not available yet.
+              </p>
+            )}
+          </div>
 
           {/* Actions */}
           {actionError && (

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -245,9 +245,9 @@ describe('TradeDetail page', () => {
         expect(screen.getByText('partner')).toBeInTheDocument();
     });
 
-    it('shows shipping address when status is not confirmed', async () => {
+    it('shows shipping address when status is confirmed', async () => {
         const trade = makeTrade({
-            status: 'shipping',
+            status: 'confirmed',
             partner_addresses: {
                 'user-2': {
                     full_name: 'Alice Reader',


### PR DESCRIPTION
## Summary
This PR fixes the match-based trade handoff after both users accept a match.

Previously, users could land in the Matches "Accepted" tab, see a completed match, but have no direct path from that screen to continue the trade shipping lifecycle.

## Root Cause
- Match records correctly transition to `completed` when both legs are accepted.
- The trade is created (`confirmed`) and shipping actions exist on trade detail.
- But the accepted match card did not expose a direct match -> trade navigation path.
- E2E flow did not require this handoff path, so the regression could slip through.

## Changes
### Backend
- Added `trade_id` to match serializer output when a trade exists for a match.
  - File: `apps/matching/serializers.py`

### Frontend
- Added `tradeId` mapping in match adapter.
  - File: `frontend/src/adapters/matches.js`
- Updated accepted/completed match presentation to be shipping-lifecycle oriented:
  - Added status copy: **"Waiting for shipping details"** for completed matches.
  - Added **Open Trade** action on non-proposed match cards.
  - Files: `frontend/src/pages/Matches.jsx`

### Tests
- Extended match view test to assert `trade_id` is returned for accepted/completed matches.
  - File: `apps/matching/tests/test_match_views.py`
- Strengthened full two-user front-end E2E flow to require opening trade from Matches -> Accepted before shipping/received actions.
- Stabilized wishlist helper behavior for edition-preference modal timing in the same E2E spec.
  - File: `frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js`

## Validation
- `cd .. && source /Users/bart0605/Documents/Python/bookforbook/.venv/bin/activate && pytest --no-cov apps/matching/tests/test_match_views.py -q`
- `cd frontend && npm run e2e -- e2e/specs/critical/17-full-trade-flow-ui.spec.js`

## User Impact
- Users can now continue directly from accepted match cards into the trade workflow.
- Shipping details entry, mark shipped, and mark received are reachable without guesswork.
- Regression is now covered by end-to-end UI tests.
