### PR TITLE
Rename message type values to use consistent naming convention

### DIFF
--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -436,7 +436,7 @@ export default function TradeDetail() {
                   {msgType === 'shipping_update' && (
                     <Tooltip content="Use this to share a tracking number or notify your partner of a shipping delay." />
                   )}
-                  {msgType === 'issue' && (
+                  {msgType === 'issue_report' && (
                     <Tooltip content="Use this if something has gone wrong with the trade, e.g. damaged book or no contact." />
                   )}
                 </div>

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -15,10 +15,10 @@ import styles from './TradeDetail.module.css';
 const MESSAGE_MAX_LENGTH = 1000;
 
 const MESSAGE_TYPES = [
-  { value: 'general', label: 'General' },
+  { value: 'general_note', label: 'General' },
   { value: 'shipping_update', label: 'Shipping Update' },
   { value: 'question', label: 'Question' },
-  { value: 'issue', label: 'Issue' },
+  { value: 'issue_report', label: 'Issue' },
 ];
 
 const TRADE_STATUS_CONFIG = {
@@ -34,7 +34,7 @@ export default function TradeDetail() {
   const { id } = useParams();
   const { user } = useAuth();
   const queryClient = useQueryClient();
-  const [msgType, setMsgType] = useState('general');
+  const [msgType, setMsgType] = useState('general_note');
   const [msgContent, setMsgContent] = useState('');
   const [trackingNumber, setTrackingNumber] = useState('');
   const [showShipForm, setShowShipForm] = useState(false);
@@ -398,7 +398,7 @@ export default function TradeDetail() {
                           <span className={styles.messageSender}>
                             {isMe ? 'You' : (msg.sender?.username ?? 'Partner')}
                           </span>
-                          {msg.message_type && msg.message_type !== 'general' && (
+                          {msg.message_type && msg.message_type !== 'general_note' && msg.message_type !== 'general' && (
                             <span className={`badge badge-gray ${styles.msgType}`}>
                               {msg.message_type.replace('_', ' ')}
                             </span>

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -731,7 +731,7 @@ describe('TradeDetail page', () => {
             }],
         });
         renderWithProviders(<TradeDetail />);
-        // msg.message_type !== 'general' → badge shown (covers line 399 true branch)
+        // msg.message_type is not 'general_note' or 'general' → badge shown (covers line 401 true branch)
         expect(await screen.findByText('shipping update')).toBeInTheDocument();
         expect(screen.getByText('Book shipped today!')).toBeInTheDocument();
     });
@@ -866,5 +866,18 @@ describe('TradeDetail page', () => {
         const msgTypeSelect = screen.getByRole('combobox');
         await userEvent.selectOptions(msgTypeSelect, 'shipping_update');
         expect(msgTypeSelect).toHaveValue('shipping_update');
+    });
+
+    it('shows issue_report tooltip when issue_report message type is selected', async () => {
+        trades.getDetail.mockResolvedValue({ data: makeTrade() });
+        trades.getMessages.mockResolvedValue({ data: [] });
+        renderWithProviders(<TradeDetail />);
+        await screen.findByText('My Book');
+
+        const msgTypeSelect = screen.getByRole('combobox');
+        await userEvent.selectOptions(msgTypeSelect, 'issue_report');
+        expect(msgTypeSelect).toHaveValue('issue_report');
+        // issue_report tooltip content should be rendered in the DOM
+        expect(screen.getByRole('tooltip', { name: /damaged book|no contact/i })).toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -444,7 +444,7 @@ describe('TradeDetail page', () => {
         await waitFor(() => {
             expect(trades.sendMessage).toHaveBeenCalledWith('trade-1', {
                 content: 'Ready to ship soon',
-                message_type: 'general',
+                message_type: 'general_note',
             });
         });
     });

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -65,7 +65,7 @@ function makeTrade(overrides = {}) {
     };
 }
 
-const ALL_MESSAGE_CATEGORIES = ['general', 'shipping_update', 'question', 'issue'];
+const ALL_MESSAGE_CATEGORIES = ['general_note', 'shipping_update', 'question', 'issue_report'];
 
 describe('TradeDetail page', () => {
     beforeEach(() => {
@@ -250,10 +250,10 @@ describe('TradeDetail page', () => {
     it('allows both approved traders to send messages in all categories and renders category labels', async () => {
         const approvedTrade = makeTrade({ status: 'confirmed' });
         const seedMessages = [
-            { id: 'm1', content: 'from me general', message_type: 'general', sender: { id: 'user-1', username: 'me' }, created_at: '2026-04-20T10:00:00Z' },
+            { id: 'm1', content: 'from me general', message_type: 'general_note', sender: { id: 'user-1', username: 'me' }, created_at: '2026-04-20T10:00:00Z' },
             { id: 'm2', content: 'from partner shipping', message_type: 'shipping_update', sender: { id: 'user-2', username: 'partner' }, created_at: '2026-04-20T10:01:00Z' },
             { id: 'm3', content: 'from me question', message_type: 'question', sender: { id: 'user-1', username: 'me' }, created_at: '2026-04-20T10:02:00Z' },
-            { id: 'm4', content: 'from partner issue', message_type: 'issue', sender: { id: 'user-2', username: 'partner' }, created_at: '2026-04-20T10:03:00Z' },
+            { id: 'm4', content: 'from partner issue', message_type: 'issue_report', sender: { id: 'user-2', username: 'partner' }, created_at: '2026-04-20T10:03:00Z' },
         ];
 
         // Trader A (user-1)
@@ -267,7 +267,7 @@ describe('TradeDetail page', () => {
         expect(screen.getByText('from partner shipping')).toBeInTheDocument();
         expect(screen.getByText('shipping update')).toBeInTheDocument();
         expect(screen.getByText('question')).toBeInTheDocument();
-        expect(screen.getByText('issue')).toBeInTheDocument();
+        expect(screen.getByText('issue report')).toBeInTheDocument();
 
         for (const category of ALL_MESSAGE_CATEGORIES) {
             const content = `user1-${category}`;

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -944,6 +944,6 @@ describe('TradeDetail page', () => {
         await userEvent.selectOptions(msgTypeSelect, 'issue_report');
         expect(msgTypeSelect).toHaveValue('issue_report');
         // issue_report tooltip content should be rendered in the DOM
-        expect(screen.getByRole('tooltip', { name: /damaged book|no contact/i })).toBeInTheDocument();
+        expect(screen.getByText(/damaged book|no contact/i)).toBeInTheDocument();
     });
 });

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -646,13 +646,15 @@ describe('TradeDetail page', () => {
             data: [{
                 id: 'msg-nodate',
                 content: 'Timeless message',
-                message_type: 'general',
+                message_type: 'general_note',
                 sender: { id: 'user-2', username: 'partner' },
                 // no created_at → falsy → {msg.created_at && ...} evaluates to false (covers line 403 false branch)
+                // general_note → badge suppressed (covers msg.message_type !== 'general_note' false branch)
             }],
         });
         renderWithProviders(<TradeDetail />);
         expect(await screen.findByText('Timeless message')).toBeInTheDocument();
+        expect(screen.queryByText('general note')).not.toBeInTheDocument();
     });
 
     it('shows "You" label for messages sent by the current user', async () => {


### PR DESCRIPTION
## Summary
Updated message type identifiers in the TradeDetail component to use more descriptive and consistent naming conventions with underscores.

## Key Changes
- Renamed `'general'` message type to `'general_note'` throughout the component
- Renamed `'issue'` message type to `'issue_report'` for clarity
- Updated the initial state for message type selection to use the new `'general_note'` value
- Added backward compatibility check to handle both old `'general'` and new `'general_note'` values when rendering message badges

## Implementation Details
- Updated the `MESSAGE_TYPES` configuration array with new value identifiers
- Changed the default `msgType` state initialization from `'general'` to `'general_note'`
- Enhanced the message type badge rendering logic to filter out both old and new general message type values, ensuring backward compatibility with existing messages that may still use the old `'general'` identifier

https://claude.ai/code/session_0199wGQ6x9fts7QGMrbnw334