### PR TITLE
Clarify shipping status with per-party tracking details

### DIFF
--- a/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
+++ b/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
@@ -153,9 +153,9 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
 
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
-    // Status badge updates to reflect shipped status
+    // Status badge updates to "You shipped (...)"
     await expect(
-      page.locator('.badge').filter({ hasText: /shipped/i }).first()
+      page.locator('.badge').filter({ hasText: /you shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -182,7 +182,7 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /shipped/i }).first()
+      page.locator('.badge').filter({ hasText: /both parties shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 

--- a/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
+++ b/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
@@ -153,9 +153,9 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
 
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
-    // Status badge updates to "Books in Transit"
+    // Status badge updates to reflect shipped status
     await expect(
-      page.locator('.badge').filter({ hasText: /in transit|shipping/i }).first()
+      page.locator('.badge').filter({ hasText: /shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -182,7 +182,7 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /in transit|shipping/i }).first()
+      page.locator('.badge').filter({ hasText: /shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 

--- a/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
+++ b/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
@@ -276,7 +276,7 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /shipped/i }).first()
+      page.locator('.badge').filter({ hasText: /you shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -296,7 +296,7 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /shipped/i }).first()
+      page.locator('.badge').filter({ hasText: /both parties shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 

--- a/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
+++ b/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
@@ -276,7 +276,7 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /in transit|shipping/i }).first()
+      page.locator('.badge').filter({ hasText: /shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -296,7 +296,7 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /in transit|shipping/i }).first()
+      page.locator('.badge').filter({ hasText: /shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -23,12 +23,36 @@ const MESSAGE_TYPES = [
 
 const TRADE_STATUS_CONFIG = {
   confirmed: { label: 'Confirmed — waiting to ship', cls: 'badge-blue' },
-  shipping: { label: 'Books in transit', cls: 'badge-amber' },
+  shipping: { label: 'Shipping in progress', cls: 'badge-amber' },
   one_received: { label: 'One side received', cls: 'badge-amber' },
   completed: { label: 'Completed', cls: 'badge-green' },
   disputed: { label: 'Disputed', cls: 'badge-red' },
   cancelled: { label: 'Cancelled', cls: 'badge-gray' },
 };
+
+function formatTrackingNumber(value) {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return trimmed || 'N/A';
+}
+
+function buildShippingStatusLabel(tradeView) {
+  const myTracking = formatTrackingNumber(tradeView?.myTracking);
+  const theirTracking = formatTrackingNumber(tradeView?.theirTracking);
+
+  if (tradeView?.myShipped && tradeView?.theyShipped) {
+    return `Both parties shipped (You: ${myTracking}, Partner: ${theirTracking})`;
+  }
+
+  if (tradeView?.myShipped) {
+    return `You shipped (You: ${myTracking}, Partner: N/A)`;
+  }
+
+  if (tradeView?.theyShipped) {
+    return `Partner shipped (You: N/A, Partner: ${theirTracking})`;
+  }
+
+  return 'Awaiting shipment (You: N/A, Partner: N/A)';
+}
 
 export default function TradeDetail() {
   const { id } = useParams();
@@ -128,6 +152,9 @@ export default function TradeDetail() {
   const tradeView = mapTradeForView(trade, user?.id);
 
   const statusConfig = TRADE_STATUS_CONFIG[tradeView.status] ?? { label: tradeView.status, cls: 'badge-gray' };
+  const statusLabel = tradeView.status === 'shipping'
+    ? buildShippingStatusLabel(tradeView)
+    : statusConfig.label;
 
   const myBook = tradeView.myBook;
   const theirBook = tradeView.theirBook;
@@ -173,7 +200,7 @@ export default function TradeDetail() {
                 <h1 className="page-title" style={{ marginBottom: '0.25rem' }}>
                   Trade #{trade.id}
                 </h1>
-                <span className={`badge ${statusConfig.cls}`}>{statusConfig.label}</span>
+                <span className={`badge ${statusConfig.cls}`}>{statusLabel}</span>
               </div>
               {trade.created_at && (
                 <p className={styles.tradeDate}>

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -35,20 +35,93 @@ function formatTrackingNumber(value) {
   return trimmed || 'N/A';
 }
 
+function detectCarrier(trackingNumber) {
+  const normalized = trackingNumber.toUpperCase().replace(/\s+/g, '');
+  const digitsOnly = normalized.replace(/\D/g, '');
+
+  if (/^1Z[0-9A-Z]{16}$/.test(normalized)) {
+    return 'ups';
+  }
+
+  if (
+    /^(94|93|92|95)\d{18,26}$/.test(digitsOnly) ||
+    /^420\d{5,}\d{16,}$/.test(digitsOnly) ||
+    /^(70|14|23|03)\d{14,22}$/.test(digitsOnly)
+  ) {
+    return 'usps';
+  }
+
+  if (/^\d{12}$|^\d{15}$|^\d{20}$|^\d{22}$/.test(digitsOnly)) {
+    return 'fedex';
+  }
+
+  return 'unknown';
+}
+
+function buildTrackingUrl(trackingNumber) {
+  const carrier = detectCarrier(trackingNumber);
+  const encodedTrackingNumber = encodeURIComponent(trackingNumber);
+
+  if (carrier === 'ups') {
+    return `https://www.ups.com/track?tracknum=${encodedTrackingNumber}`;
+  }
+
+  if (carrier === 'usps') {
+    return `https://tools.usps.com/go/TrackConfirmAction?tLabels=${encodedTrackingNumber}`;
+  }
+
+  if (carrier === 'fedex') {
+    return `https://www.fedex.com/fedextrack/?trknbr=${encodedTrackingNumber}`;
+  }
+
+  return `https://www.google.com/search?q=${encodedTrackingNumber}`;
+}
+
+function renderTrackingValue(rawTrackingNumber) {
+  const formattedTrackingNumber = formatTrackingNumber(rawTrackingNumber);
+  if (formattedTrackingNumber === 'N/A') {
+    return 'N/A';
+  }
+
+  return (
+    <a
+      href={buildTrackingUrl(formattedTrackingNumber)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={styles.trackingLink}
+      title="Open tracking details in a new tab"
+    >
+      {formattedTrackingNumber}
+    </a>
+  );
+}
+
 function buildShippingStatusLabel(tradeView) {
-  const myTracking = formatTrackingNumber(tradeView?.myTracking);
-  const theirTracking = formatTrackingNumber(tradeView?.theirTracking);
+  const myTracking = tradeView?.myShipped ? tradeView?.myTracking : null;
+  const theirTracking = tradeView?.theyShipped ? tradeView?.theirTracking : null;
 
   if (tradeView?.myShipped && tradeView?.theyShipped) {
-    return `Both parties shipped (You: ${myTracking}, Partner: ${theirTracking})`;
+    return (
+      <>
+        Both parties shipped (You: {renderTrackingValue(myTracking)}, Partner: {renderTrackingValue(theirTracking)})
+      </>
+    );
   }
 
   if (tradeView?.myShipped) {
-    return `You shipped (You: ${myTracking}, Partner: N/A)`;
+    return (
+      <>
+        You shipped (You: {renderTrackingValue(myTracking)}, Partner: {renderTrackingValue(null)})
+      </>
+    );
   }
 
   if (tradeView?.theyShipped) {
-    return `Partner shipped (You: N/A, Partner: ${theirTracking})`;
+    return (
+      <>
+        Partner shipped (You: {renderTrackingValue(null)}, Partner: {renderTrackingValue(theirTracking)})
+      </>
+    );
   }
 
   return 'Awaiting shipment (You: N/A, Partner: N/A)';

--- a/frontend/src/pages/TradeDetail.module.css
+++ b/frontend/src/pages/TradeDetail.module.css
@@ -62,6 +62,16 @@
   margin-top: 0.25rem;
 }
 
+.trackingLink {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.trackingLink:hover {
+  text-decoration-thickness: 2px;
+}
+
 /* Exchange grid */
 .exchangeGrid {
   display: grid;

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -153,7 +153,7 @@ describe('TradeDetail page', () => {
         expect(await screen.findByRole('button', { name: /mark book received/i })).toBeInTheDocument();
     });
 
-    it('shows detailed shipping status when both parties have shipped', async () => {
+    it('shows detailed shipping status with carrier-aware tracking links', async () => {
         const trade = makeTrade({
             status: 'shipping',
             shipments: [
@@ -161,7 +161,7 @@ describe('TradeDetail page', () => {
                     sender: { id: 'user-1', username: 'me' },
                     receiver: { id: 'user-2', username: 'partner' },
                     status: 'shipped',
-                    tracking_number: 'MY-TRACK-1',
+                    tracking_number: '1Z999AA10123456784',
                     shipped_at: '2026-04-22T00:00:00Z',
                     user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
                 },
@@ -169,7 +169,7 @@ describe('TradeDetail page', () => {
                     sender: { id: 'user-2', username: 'partner' },
                     receiver: { id: 'user-1', username: 'me' },
                     status: 'shipped',
-                    tracking_number: 'THEIR-TRACK-2',
+                    tracking_number: '9400100000000000000000',
                     shipped_at: '2026-04-23T00:00:00Z',
                     user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
                 },
@@ -180,7 +180,49 @@ describe('TradeDetail page', () => {
 
         renderWithProviders(<TradeDetail />);
 
-        expect(await screen.findByText('Both parties shipped (You: MY-TRACK-1, Partner: THEIR-TRACK-2)')).toBeInTheDocument();
+        expect(await screen.findByText(/Both parties shipped/i)).toBeInTheDocument();
+
+        const upsTrackingLink = screen.getByRole('link', { name: '1Z999AA10123456784' });
+        expect(upsTrackingLink).toHaveAttribute('href', 'https://www.ups.com/track?tracknum=1Z999AA10123456784');
+        expect(upsTrackingLink).toHaveAttribute('target', '_blank');
+        expect(upsTrackingLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+        const uspsTrackingLink = screen.getByRole('link', { name: '9400100000000000000000' });
+        expect(uspsTrackingLink).toHaveAttribute('href', 'https://tools.usps.com/go/TrackConfirmAction?tLabels=9400100000000000000000');
+        expect(uspsTrackingLink).toHaveAttribute('target', '_blank');
+        expect(uspsTrackingLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('falls back to web search for unknown tracking format', async () => {
+        const trade = makeTrade({
+            status: 'shipping',
+            shipments: [
+                {
+                    sender: { id: 'user-1', username: 'me' },
+                    receiver: { id: 'user-2', username: 'partner' },
+                    status: 'shipped',
+                    tracking_number: 'MY-CUSTOM-TRACKING',
+                    shipped_at: '2026-04-22T00:00:00Z',
+                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                },
+                {
+                    sender: { id: 'user-2', username: 'partner' },
+                    receiver: { id: 'user-1', username: 'me' },
+                    status: 'pending',
+                    tracking_number: '',
+                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                },
+            ],
+        });
+        trades.getDetail.mockResolvedValue({ data: trade });
+        trades.getMessages.mockResolvedValue({ data: [] });
+
+        renderWithProviders(<TradeDetail />);
+
+        const fallbackTrackingLink = await screen.findByRole('link', { name: 'MY-CUSTOM-TRACKING' });
+        expect(fallbackTrackingLink).toHaveAttribute('href', 'https://www.google.com/search?q=MY-CUSTOM-TRACKING');
+        expect(fallbackTrackingLink).toHaveAttribute('target', '_blank');
+        expect(fallbackTrackingLink).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
     it('shows N/A tracking fallback in detailed shipping status', async () => {
@@ -461,7 +503,7 @@ describe('TradeDetail page', () => {
         trades.getDetail.mockResolvedValue({ data: trade });
         trades.getMessages.mockResolvedValue({ data: [] });
         renderWithProviders(<TradeDetail />);
-        expect(await screen.findByText('TRK-ABC')).toBeInTheDocument();
+        expect(await screen.findByRole('link', { name: 'TRK-ABC' })).toBeInTheDocument();
         const shipped = await screen.findAllByText('Shipped');
         expect(shipped.length).toBeGreaterThan(0);
     });

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -153,6 +153,65 @@ describe('TradeDetail page', () => {
         expect(await screen.findByRole('button', { name: /mark book received/i })).toBeInTheDocument();
     });
 
+    it('shows detailed shipping status when both parties have shipped', async () => {
+        const trade = makeTrade({
+            status: 'shipping',
+            shipments: [
+                {
+                    sender: { id: 'user-1', username: 'me' },
+                    receiver: { id: 'user-2', username: 'partner' },
+                    status: 'shipped',
+                    tracking_number: 'MY-TRACK-1',
+                    shipped_at: '2026-04-22T00:00:00Z',
+                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                },
+                {
+                    sender: { id: 'user-2', username: 'partner' },
+                    receiver: { id: 'user-1', username: 'me' },
+                    status: 'shipped',
+                    tracking_number: 'THEIR-TRACK-2',
+                    shipped_at: '2026-04-23T00:00:00Z',
+                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                },
+            ],
+        });
+        trades.getDetail.mockResolvedValue({ data: trade });
+        trades.getMessages.mockResolvedValue({ data: [] });
+
+        renderWithProviders(<TradeDetail />);
+
+        expect(await screen.findByText('Both parties shipped (You: MY-TRACK-1, Partner: THEIR-TRACK-2)')).toBeInTheDocument();
+    });
+
+    it('shows N/A tracking fallback in detailed shipping status', async () => {
+        const trade = makeTrade({
+            status: 'shipping',
+            shipments: [
+                {
+                    sender: { id: 'user-1', username: 'me' },
+                    receiver: { id: 'user-2', username: 'partner' },
+                    status: 'shipped',
+                    tracking_number: '',
+                    shipped_at: '2026-04-22T00:00:00Z',
+                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                },
+                {
+                    sender: { id: 'user-2', username: 'partner' },
+                    receiver: { id: 'user-1', username: 'me' },
+                    status: 'pending',
+                    tracking_number: '',
+                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                },
+            ],
+        });
+        trades.getDetail.mockResolvedValue({ data: trade });
+        trades.getMessages.mockResolvedValue({ data: [] });
+
+        renderWithProviders(<TradeDetail />);
+
+        expect(await screen.findByText('You shipped (You: N/A, Partner: N/A)')).toBeInTheDocument();
+    });
+
     it('shows "Rate Trade Partner" button when trade is completed and user has not rated', async () => {
         const trade = makeTrade({
             status: 'completed',

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -254,6 +254,67 @@ describe('TradeDetail page', () => {
         expect(await screen.findByText('You shipped (You: N/A, Partner: N/A)')).toBeInTheDocument();
     });
 
+    it('shows partner-only shipped label when only partner has shipped', async () => {
+        const trade = makeTrade({
+            status: 'shipping',
+            shipments: [
+                {
+                    sender: { id: 'user-1', username: 'me' },
+                    receiver: { id: 'user-2', username: 'partner' },
+                    status: 'pending',
+                    tracking_number: '',
+                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                },
+                {
+                    sender: { id: 'user-2', username: 'partner' },
+                    receiver: { id: 'user-1', username: 'me' },
+                    status: 'shipped',
+                    tracking_number: 'TRK-PARTNER',
+                    shipped_at: '2026-04-22T00:00:00Z',
+                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                },
+            ],
+        });
+        trades.getDetail.mockResolvedValue({ data: trade });
+        trades.getMessages.mockResolvedValue({ data: [] });
+
+        renderWithProviders(<TradeDetail />);
+
+        expect(await screen.findByText(/Partner shipped/i)).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'TRK-PARTNER' })).toBeInTheDocument();
+        expect(screen.queryByRole('link', { name: /You:/i })).not.toBeInTheDocument();
+        const badge = screen.getByText(/Partner shipped/i).closest('span') ?? screen.getByText(/Partner shipped/i);
+        expect(badge).toHaveTextContent('N/A');
+    });
+
+    it('shows awaiting shipment label when neither party has shipped', async () => {
+        const trade = makeTrade({
+            status: 'shipping',
+            shipments: [
+                {
+                    sender: { id: 'user-1', username: 'me' },
+                    receiver: { id: 'user-2', username: 'partner' },
+                    status: 'pending',
+                    tracking_number: '',
+                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                },
+                {
+                    sender: { id: 'user-2', username: 'partner' },
+                    receiver: { id: 'user-1', username: 'me' },
+                    status: 'pending',
+                    tracking_number: '',
+                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                },
+            ],
+        });
+        trades.getDetail.mockResolvedValue({ data: trade });
+        trades.getMessages.mockResolvedValue({ data: [] });
+
+        renderWithProviders(<TradeDetail />);
+
+        expect(await screen.findByText('Awaiting shipment (You: N/A, Partner: N/A)')).toBeInTheDocument();
+    });
+
     it('shows "Rate Trade Partner" button when trade is completed and user has not rated', async () => {
         const trade = makeTrade({
             status: 'completed',


### PR DESCRIPTION
## Summary
- replace the generic `Books in transit` shipping badge text with explicit shipment state details
- show whether both parties shipped, or which party has shipped
- include tracking values in the shipping badge text and use `N/A` when a tracking number is missing

## Implementation
- update `TradeDetail` to compute a dynamic shipping label via `buildShippingStatusLabel`
- keep existing status badge colors/classes while changing only the displayed shipping text

## Tests
- add test for both-parties-shipped label with both tracking numbers
- add test for missing tracking number fallback to `N/A`
- run `npm run test:run -- src/pages/TradeDetail.test.jsx` (passes)

## Notes
- no backend/API changes required; this uses existing trade shipment fields already returned by the frontend adapter.