### PR TITLE
Fix Trade page one-sided shipped status showing N/A tracking

### DIFF
--- a/frontend/src/adapters/trades.js
+++ b/frontend/src/adapters/trades.js
@@ -10,21 +10,64 @@ function isReceivedStatus(status) {
   return status === "received";
 }
 
+function pickFirstNonNil(...values) {
+  for (const value of values) {
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+function getParticipantId(participant, fallbackId) {
+  if (participant && typeof participant === "object") {
+    return pickFirstNonNil(participant.id, participant.user_id, participant.userId, participant.uuid, fallbackId);
+  }
+  return pickFirstNonNil(participant, fallbackId);
+}
+
+function normalizeParticipant(participant, fallbackId) {
+  if (participant && typeof participant === "object") {
+    return {
+      ...participant,
+      id: getParticipantId(participant, fallbackId),
+    };
+  }
+
+  const id = getParticipantId(participant, fallbackId);
+  return id ? { id } : null;
+}
+
 export function mapTradeForView(trade, currentUserId) {
   const shipments = Array.isArray(trade?.shipments) ? trade.shipments : [];
 
   const myOutgoing = currentUserId
-    ? shipments.find((shipment) => idEq(shipment?.sender?.id, currentUserId))
+    ? shipments.find((shipment) => idEq(
+      getParticipantId(shipment?.sender, pickFirstNonNil(shipment?.sender_id, shipment?.senderId)),
+      currentUserId
+    ))
     : null;
   const myIncoming = currentUserId
-    ? shipments.find((shipment) => idEq(shipment?.receiver?.id, currentUserId))
+    ? shipments.find((shipment) => idEq(
+      getParticipantId(shipment?.receiver, pickFirstNonNil(shipment?.receiver_id, shipment?.receiverId)),
+      currentUserId
+    ))
     : null;
+
+  const outgoingReceiver = normalizeParticipant(
+    myOutgoing?.receiver,
+    pickFirstNonNil(myOutgoing?.receiver_id, myOutgoing?.receiverId)
+  );
+  const incomingSender = normalizeParticipant(
+    myIncoming?.sender,
+    pickFirstNonNil(myIncoming?.sender_id, myIncoming?.senderId)
+  );
 
   const partner =
     trade?.partner ??
     trade?.other_user ??
-    myOutgoing?.receiver ??
-    myIncoming?.sender ??
+    outgoingReceiver ??
+    incomingSender ??
     null;
 
   const partnerAddressRaw = partner?.id
@@ -53,15 +96,23 @@ export function mapTradeForView(trade, currentUserId) {
     theirBook,
     partner,
     partnerAddress,
-    myShipped: myOutgoing ? isShippedStatus(myOutgoing.status) : Boolean(trade?.my_shipped),
-    myShippedAt: myOutgoing?.shipped_at ?? trade?.my_shipped_at ?? null,
-    myTracking: myOutgoing?.tracking_number ?? trade?.my_tracking ?? "",
-    iReceived: myIncoming ? isReceivedStatus(myIncoming.status) : Boolean(trade?.i_received),
-    theyShipped: myIncoming ? isShippedStatus(myIncoming.status) : Boolean(trade?.they_shipped),
-    theyShippedAt: myIncoming?.shipped_at ?? trade?.they_shipped_at ?? null,
-    theirTracking: myIncoming?.tracking_number ?? trade?.their_tracking ?? "",
-    theyReceived: myOutgoing ? isReceivedStatus(myOutgoing.status) : Boolean(trade?.they_received),
-    iRated: Boolean(trade?.i_rated),
+    myShipped: myOutgoing
+      ? isShippedStatus(myOutgoing.status)
+      : Boolean(pickFirstNonNil(trade?.my_shipped, trade?.myShipped)),
+    myShippedAt: pickFirstNonNil(myOutgoing?.shipped_at, myOutgoing?.shippedAt, trade?.my_shipped_at, trade?.myShippedAt) ?? null,
+    myTracking: pickFirstNonNil(myOutgoing?.tracking_number, myOutgoing?.trackingNumber, myOutgoing?.tracking, trade?.my_tracking, trade?.myTracking) ?? "",
+    iReceived: myIncoming
+      ? isReceivedStatus(myIncoming.status)
+      : Boolean(pickFirstNonNil(trade?.i_received, trade?.iReceived)),
+    theyShipped: myIncoming
+      ? isShippedStatus(myIncoming.status)
+      : Boolean(pickFirstNonNil(trade?.they_shipped, trade?.theyShipped)),
+    theyShippedAt: pickFirstNonNil(myIncoming?.shipped_at, myIncoming?.shippedAt, trade?.they_shipped_at, trade?.theyShippedAt) ?? null,
+    theirTracking: pickFirstNonNil(myIncoming?.tracking_number, myIncoming?.trackingNumber, myIncoming?.tracking, trade?.their_tracking, trade?.theirTracking) ?? "",
+    theyReceived: myOutgoing
+      ? isReceivedStatus(myOutgoing.status)
+      : Boolean(pickFirstNonNil(trade?.they_received, trade?.theyReceived)),
+    iRated: Boolean(pickFirstNonNil(trade?.i_rated, trade?.iRated)),
   };
 }
 

--- a/frontend/src/adapters/trades.test.js
+++ b/frontend/src/adapters/trades.test.js
@@ -60,4 +60,34 @@ describe('trades adapter', () => {
       book_condition_accurate: true,
     });
   });
+
+  it('maps camelCase shipment fields for one-sided shipped trades', () => {
+    const trade = {
+      id: 't2',
+      status: 'shipping',
+      shipments: [
+        {
+          sender: { id: 'u1', username: 'me' },
+          receiver: { id: 'u2', username: 'alice' },
+          status: 'shipped',
+          trackingNumber: 'CAMEL-TRACK-1',
+          shippedAt: '2026-04-25T00:00:00Z',
+          user_book: { condition: 'good', book: { title: 'Dune' } },
+        },
+        {
+          senderId: 'u2',
+          receiverId: 'u1',
+          status: 'pending',
+          user_book: { condition: 'very_good', book: { title: 'Hyperion' } },
+        },
+      ],
+    };
+
+    const vm = mapTradeForView(trade, 'u1');
+
+    expect(vm.myShipped).toBe(true);
+    expect(vm.theyShipped).toBe(false);
+    expect(vm.myTracking).toBe('CAMEL-TRACK-1');
+    expect(vm.myShippedAt).toBe('2026-04-25T00:00:00Z');
+  });
 });

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -225,6 +225,40 @@ describe('TradeDetail page', () => {
         expect(fallbackTrackingLink).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
+    it('shows one-sided shipped tracking when shipment uses camelCase fields', async () => {
+        const trade = makeTrade({
+            status: 'shipping',
+            shipments: [
+                {
+                    sender: { id: 'user-1', username: 'me' },
+                    receiver: { id: 'user-2', username: 'partner' },
+                    status: 'shipped',
+                    trackingNumber: 'CAMEL-12345',
+                    shippedAt: '2026-04-22T00:00:00Z',
+                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                },
+                {
+                    senderId: 'user-2',
+                    receiverId: 'user-1',
+                    status: 'pending',
+                    trackingNumber: '',
+                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                },
+            ],
+        });
+        trades.getDetail.mockResolvedValue({ data: trade });
+        trades.getMessages.mockResolvedValue({ data: [] });
+
+        renderWithProviders(<TradeDetail />);
+
+        expect(await screen.findByText(/You shipped/i)).toBeInTheDocument();
+
+        const trackingLink = screen.getByRole('link', { name: 'CAMEL-12345' });
+        expect(trackingLink).toHaveAttribute('href', 'https://www.google.com/search?q=CAMEL-12345');
+        expect(trackingLink).toHaveAttribute('target', '_blank');
+        expect(trackingLink).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
     it('shows N/A tracking fallback in detailed shipping status', async () => {
         const trade = makeTrade({
             status: 'shipping',


### PR DESCRIPTION
## Summary
- fix Trade view-model mapping to handle shipment field variants (`tracking_number`/`trackingNumber`, `shipped_at`/`shippedAt`, and sender/receiver id aliases)
- ensure one-sided shipped badges on Trade detail correctly display the shipped side's tracking value instead of falling back to `N/A`
- add regression coverage in both adapter and Trade detail page tests

## Root cause
The Trade detail status badge relied on adapter fields that only mapped snake_case shipment keys. When data arrived with alternate key shapes, tracking was dropped from the mapped model, causing the status text to render `N/A` for the shipped side.

## Tests
- `npm run test:run -- src/adapters/trades.test.js src/pages/TradeDetail.test.jsx`