### PR TITLE
Add postgresql-client to system dependencies

### DIFF
--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -1,7 +1,7 @@
 [phases.setup]
 # System packages required by Python dependencies.
 # zbar: required by pyzbar for barcode/ISBN image extraction.
-aptPkgs = ["libzbar0"]
+aptPkgs = ["libzbar0", "postgresql-client"]
 
 [variables]
 # Pin Python version to match runtime.txt / local dev environment.


### PR DESCRIPTION
## Summary
Added `postgresql-client` to the list of system packages required during the setup phase.

## Changes
- Added `postgresql-client` to the `aptPkgs` list in `nixpacks.toml` alongside the existing `libzbar0` dependency

## Details
This change ensures that PostgreSQL client tools are available in the build environment, likely needed for database operations or migrations during application setup or runtime.

https://claude.ai/code/session_01Q5Sx9dMvAErP3wPwh5sEvQ