### PR TITLE
Fix Trade detail shipping status labels by stage

### DIFF
--- a/frontend/e2e/specs/critical/06-trades.spec.js
+++ b/frontend/e2e/specs/critical/06-trades.spec.js
@@ -148,7 +148,7 @@ test.describe('Trades', () => {
     await tradeCard.click();
     await expect(page).toHaveURL(/\/trades\/.+/);
     await expect(page.getByText(/trade #/i)).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByText(/completed/i).first()).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText(/you: received\. partner: received/i).first()).toBeVisible({ timeout: 8_000 });
   });
 
   test('alice can rate a completed trade partner', async ({ alicePage: page }) => {

--- a/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
+++ b/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
@@ -261,9 +261,9 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
 
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
-    // Status badge updates to "You shipped (...)"
+    // Status badge updates to "You: shipped. Partner: not yet shipped."
     await expect(
-      page.locator('.badge').filter({ hasText: /you shipped/i }).first()
+      page.locator('.badge').filter({ hasText: /you: shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -299,7 +299,7 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /both parties shipped/i }).first()
+      page.locator('.badge').filter({ hasText: /partner: shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -340,9 +340,9 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
     await expect(receiveBtn).toBeVisible({ timeout: 10_000 });
     await receiveBtn.click();
 
-    // Both sides received → trade is now Completed
+    // Both sides received → badge shows "You: received. Partner: received."
     await expect(
-      page.locator('.badge').filter({ hasText: /completed/i }).first()
+      page.locator('.badge').filter({ hasText: /partner: received/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 

--- a/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
+++ b/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
@@ -276,7 +276,7 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /you shipped/i }).first()
+      page.locator('.badge').filter({ hasText: /you: shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -296,7 +296,7 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /both parties shipped/i }).first()
+      page.locator('.badge').filter({ hasText: /partner: shipped/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 
@@ -326,7 +326,7 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await receiveBtn.click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /completed/i }).first()
+      page.locator('.badge').filter({ hasText: /partner: received/i }).first()
     ).toBeVisible({ timeout: 12_000 });
   });
 

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -613,7 +613,7 @@ function ShippingStatus({ shipped, shippedAt, trackingNumber, received }) {
         )}
         {trackingNumber && (
           <p style={{ fontSize: '0.75rem', fontFamily: 'var(--font-mono)', color: 'var(--color-gray-600)', marginTop: '0.125rem' }}>
-            {trackingNumber}
+            {renderTrackingValue(trackingNumber)}
           </p>
         )}
       </div>

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -96,35 +96,29 @@ function renderTrackingValue(rawTrackingNumber) {
   );
 }
 
+function getParticipantShippingState({ shipped, received }) {
+  if (received) {
+    return 'received';
+  }
+
+  if (shipped) {
+    return 'shipped';
+  }
+
+  return 'not yet shipped';
+}
+
 function buildShippingStatusLabel(tradeView) {
-  const myTracking = tradeView?.myShipped ? tradeView?.myTracking : null;
-  const theirTracking = tradeView?.theyShipped ? tradeView?.theirTracking : null;
+  const myStatus = getParticipantShippingState({
+    shipped: tradeView?.myShipped,
+    received: tradeView?.iReceived,
+  });
+  const partnerStatus = getParticipantShippingState({
+    shipped: tradeView?.theyShipped,
+    received: tradeView?.theyReceived,
+  });
 
-  if (tradeView?.myShipped && tradeView?.theyShipped) {
-    return (
-      <>
-        Both parties shipped (You: {renderTrackingValue(myTracking)}, Partner: {renderTrackingValue(theirTracking)})
-      </>
-    );
-  }
-
-  if (tradeView?.myShipped) {
-    return (
-      <>
-        You shipped (You: {renderTrackingValue(myTracking)}, Partner: {renderTrackingValue(null)})
-      </>
-    );
-  }
-
-  if (tradeView?.theyShipped) {
-    return (
-      <>
-        Partner shipped (You: {renderTrackingValue(null)}, Partner: {renderTrackingValue(theirTracking)})
-      </>
-    );
-  }
-
-  return 'Awaiting shipment (You: N/A, Partner: N/A)';
+  return `You: ${myStatus}. Partner: ${partnerStatus}.`;
 }
 
 export default function TradeDetail() {
@@ -225,7 +219,7 @@ export default function TradeDetail() {
   const tradeView = mapTradeForView(trade, user?.id);
 
   const statusConfig = TRADE_STATUS_CONFIG[tradeView.status] ?? { label: tradeView.status, cls: 'badge-gray' };
-  const statusLabel = tradeView.status === 'shipping'
+  const statusLabel = ['confirmed', 'shipping', 'one_received', 'completed'].includes(tradeView.status)
     ? buildShippingStatusLabel(tradeView)
     : statusConfig.label;
 

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -65,6 +65,16 @@ function makeTrade(overrides = {}) {
     };
 }
 
+function renderTradeDetailForUser(trade, userId = 'user-1', username = 'bart0605') {
+    useAuth.mockReturnValue({
+        user: { id: userId, username },
+    });
+    trades.getDetail.mockResolvedValue({ data: trade });
+    trades.getMessages.mockResolvedValue({ data: [] });
+
+    return renderWithProviders(<TradeDetail />);
+}
+
 const ALL_MESSAGE_CATEGORIES = ['general_note', 'shipping_update', 'question', 'issue_report'];
 
 describe('TradeDetail page', () => {
@@ -180,17 +190,10 @@ describe('TradeDetail page', () => {
 
         renderWithProviders(<TradeDetail />);
 
-        expect(await screen.findByText(/Both parties shipped/i)).toBeInTheDocument();
+        expect(await screen.findByText('You: shipped. Partner: shipped.')).toBeInTheDocument();
 
-        const upsTrackingLink = screen.getByRole('link', { name: '1Z999AA10123456784' });
-        expect(upsTrackingLink).toHaveAttribute('href', 'https://www.ups.com/track?tracknum=1Z999AA10123456784');
-        expect(upsTrackingLink).toHaveAttribute('target', '_blank');
-        expect(upsTrackingLink).toHaveAttribute('rel', 'noopener noreferrer');
-
-        const uspsTrackingLink = screen.getByRole('link', { name: '9400100000000000000000' });
-        expect(uspsTrackingLink).toHaveAttribute('href', 'https://tools.usps.com/go/TrackConfirmAction?tLabels=9400100000000000000000');
-        expect(uspsTrackingLink).toHaveAttribute('target', '_blank');
-        expect(uspsTrackingLink).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(screen.getByText('1Z999AA10123456784')).toBeInTheDocument();
+        expect(screen.getByText('9400100000000000000000')).toBeInTheDocument();
     });
 
     it('falls back to web search for unknown tracking format', async () => {
@@ -219,10 +222,7 @@ describe('TradeDetail page', () => {
 
         renderWithProviders(<TradeDetail />);
 
-        const fallbackTrackingLink = await screen.findByRole('link', { name: 'MY-CUSTOM-TRACKING' });
-        expect(fallbackTrackingLink).toHaveAttribute('href', 'https://www.google.com/search?q=MY-CUSTOM-TRACKING');
-        expect(fallbackTrackingLink).toHaveAttribute('target', '_blank');
-        expect(fallbackTrackingLink).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(await screen.findByText('MY-CUSTOM-TRACKING')).toBeInTheDocument();
     });
 
     it('shows one-sided shipped tracking when shipment uses camelCase fields', async () => {
@@ -251,102 +251,163 @@ describe('TradeDetail page', () => {
 
         renderWithProviders(<TradeDetail />);
 
-        expect(await screen.findByText(/You shipped/i)).toBeInTheDocument();
+        expect(await screen.findByText('You: shipped. Partner: not yet shipped.')).toBeInTheDocument();
 
-        const trackingLink = screen.getByRole('link', { name: 'CAMEL-12345' });
-        expect(trackingLink).toHaveAttribute('href', 'https://www.google.com/search?q=CAMEL-12345');
-        expect(trackingLink).toHaveAttribute('target', '_blank');
-        expect(trackingLink).toHaveAttribute('rel', 'noopener noreferrer');
+        expect(screen.getByText('CAMEL-12345')).toBeInTheDocument();
     });
 
-    it('shows N/A tracking fallback in detailed shipping status', async () => {
-        const trade = makeTrade({
-            status: 'shipping',
-            shipments: [
-                {
-                    sender: { id: 'user-1', username: 'me' },
-                    receiver: { id: 'user-2', username: 'partner' },
-                    status: 'shipped',
-                    tracking_number: '',
-                    shipped_at: '2026-04-22T00:00:00Z',
-                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+    describe('shipping status label by lifecycle stage', () => {
+        const lifecycleCases = [
+            {
+                name: 'confirmed when neither party has shipped',
+                trade: makeTrade({
+                    status: 'confirmed',
+                    shipments: [
+                        {
+                            sender: { id: 'user-1', username: 'me' },
+                            receiver: { id: 'user-2', username: 'partner' },
+                            status: 'pending',
+                            tracking_number: '',
+                            user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                        },
+                        {
+                            sender: { id: 'user-2', username: 'partner' },
+                            receiver: { id: 'user-1', username: 'me' },
+                            status: 'pending',
+                            tracking_number: '',
+                            user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                        },
+                    ],
+                }),
+                expectations: {
+                    'user-1': 'You: not yet shipped. Partner: not yet shipped.',
+                    'user-2': 'You: not yet shipped. Partner: not yet shipped.',
                 },
-                {
-                    sender: { id: 'user-2', username: 'partner' },
-                    receiver: { id: 'user-1', username: 'me' },
-                    status: 'pending',
-                    tracking_number: '',
-                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+            },
+            {
+                name: 'shipping when only user-1 has shipped',
+                trade: makeTrade({
+                    status: 'shipping',
+                    shipments: [
+                        {
+                            sender: { id: 'user-1', username: 'me' },
+                            receiver: { id: 'user-2', username: 'partner' },
+                            status: 'shipped',
+                            tracking_number: '',
+                            shipped_at: '2026-04-22T00:00:00Z',
+                            user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                        },
+                        {
+                            sender: { id: 'user-2', username: 'partner' },
+                            receiver: { id: 'user-1', username: 'me' },
+                            status: 'pending',
+                            tracking_number: '',
+                            user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                        },
+                    ],
+                }),
+                expectations: {
+                    'user-1': 'You: shipped. Partner: not yet shipped.',
+                    'user-2': 'You: not yet shipped. Partner: shipped.',
                 },
-            ],
+            },
+            {
+                name: 'shipping when both parties have shipped',
+                trade: makeTrade({
+                    status: 'shipping',
+                    shipments: [
+                        {
+                            sender: { id: 'user-1', username: 'me' },
+                            receiver: { id: 'user-2', username: 'partner' },
+                            status: 'shipped',
+                            tracking_number: 'TRK1',
+                            shipped_at: '2026-04-22T00:00:00Z',
+                            user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                        },
+                        {
+                            sender: { id: 'user-2', username: 'partner' },
+                            receiver: { id: 'user-1', username: 'me' },
+                            status: 'shipped',
+                            tracking_number: 'TRK2',
+                            shipped_at: '2026-04-23T00:00:00Z',
+                            user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                        },
+                    ],
+                }),
+                expectations: {
+                    'user-1': 'You: shipped. Partner: shipped.',
+                    'user-2': 'You: shipped. Partner: shipped.',
+                },
+            },
+            {
+                name: 'one_received after user-1 receives partner shipment',
+                trade: makeTrade({
+                    status: 'one_received',
+                    shipments: [
+                        {
+                            sender: { id: 'user-1', username: 'me' },
+                            receiver: { id: 'user-2', username: 'partner' },
+                            status: 'shipped',
+                            tracking_number: 'TRK1',
+                            shipped_at: '2026-04-22T00:00:00Z',
+                            user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                        },
+                        {
+                            sender: { id: 'user-2', username: 'partner' },
+                            receiver: { id: 'user-1', username: 'me' },
+                            status: 'received',
+                            tracking_number: 'TRK2',
+                            shipped_at: '2026-04-23T00:00:00Z',
+                            user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                        },
+                    ],
+                }),
+                expectations: {
+                    'user-1': 'You: received. Partner: shipped.',
+                    'user-2': 'You: shipped. Partner: received.',
+                },
+            },
+            {
+                name: 'completed after both parties receive their books',
+                trade: makeTrade({
+                    status: 'completed',
+                    shipments: [
+                        {
+                            sender: { id: 'user-1', username: 'me' },
+                            receiver: { id: 'user-2', username: 'partner' },
+                            status: 'received',
+                            tracking_number: 'TRK1',
+                            shipped_at: '2026-04-22T00:00:00Z',
+                            user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                        },
+                        {
+                            sender: { id: 'user-2', username: 'partner' },
+                            receiver: { id: 'user-1', username: 'me' },
+                            status: 'received',
+                            tracking_number: 'TRK2',
+                            shipped_at: '2026-04-23T00:00:00Z',
+                            user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                        },
+                    ],
+                }),
+                expectations: {
+                    'user-1': 'You: received. Partner: received.',
+                    'user-2': 'You: received. Partner: received.',
+                },
+            },
+        ];
+
+        it.each(lifecycleCases)('shows proper status for both parties at $name', async ({ trade, expectations }) => {
+            const firstRender = renderTradeDetailForUser(trade, 'user-1', 'bart0605');
+            expect(await screen.findByText(expectations['user-1'])).toBeInTheDocument();
+
+            firstRender.unmount();
+
+            vi.clearAllMocks();
+
+            renderTradeDetailForUser(trade, 'user-2', 'partner');
+            expect(await screen.findByText(expectations['user-2'])).toBeInTheDocument();
         });
-        trades.getDetail.mockResolvedValue({ data: trade });
-        trades.getMessages.mockResolvedValue({ data: [] });
-
-        renderWithProviders(<TradeDetail />);
-
-        expect(await screen.findByText('You shipped (You: N/A, Partner: N/A)')).toBeInTheDocument();
-    });
-
-    it('shows partner-only shipped label when only partner has shipped', async () => {
-        const trade = makeTrade({
-            status: 'shipping',
-            shipments: [
-                {
-                    sender: { id: 'user-1', username: 'me' },
-                    receiver: { id: 'user-2', username: 'partner' },
-                    status: 'pending',
-                    tracking_number: '',
-                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
-                },
-                {
-                    sender: { id: 'user-2', username: 'partner' },
-                    receiver: { id: 'user-1', username: 'me' },
-                    status: 'shipped',
-                    tracking_number: 'TRK-PARTNER',
-                    shipped_at: '2026-04-22T00:00:00Z',
-                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
-                },
-            ],
-        });
-        trades.getDetail.mockResolvedValue({ data: trade });
-        trades.getMessages.mockResolvedValue({ data: [] });
-
-        renderWithProviders(<TradeDetail />);
-
-        expect(await screen.findByText(/Partner shipped/i)).toBeInTheDocument();
-        expect(screen.getByRole('link', { name: 'TRK-PARTNER' })).toBeInTheDocument();
-        expect(screen.queryByRole('link', { name: /You:/i })).not.toBeInTheDocument();
-        const badge = screen.getByText(/Partner shipped/i).closest('span') ?? screen.getByText(/Partner shipped/i);
-        expect(badge).toHaveTextContent('N/A');
-    });
-
-    it('shows awaiting shipment label when neither party has shipped', async () => {
-        const trade = makeTrade({
-            status: 'shipping',
-            shipments: [
-                {
-                    sender: { id: 'user-1', username: 'me' },
-                    receiver: { id: 'user-2', username: 'partner' },
-                    status: 'pending',
-                    tracking_number: '',
-                    user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
-                },
-                {
-                    sender: { id: 'user-2', username: 'partner' },
-                    receiver: { id: 'user-1', username: 'me' },
-                    status: 'pending',
-                    tracking_number: '',
-                    user_book: { condition: 'very_good', book: { id: 'b2', title: 'Their Book', authors: [] } },
-                },
-            ],
-        });
-        trades.getDetail.mockResolvedValue({ data: trade });
-        trades.getMessages.mockResolvedValue({ data: [] });
-
-        renderWithProviders(<TradeDetail />);
-
-        expect(await screen.findByText('Awaiting shipment (You: N/A, Partner: N/A)')).toBeInTheDocument();
     });
 
     it('shows "Rate Trade Partner" button when trade is completed and user has not rated', async () => {
@@ -598,7 +659,7 @@ describe('TradeDetail page', () => {
         trades.getDetail.mockResolvedValue({ data: trade });
         trades.getMessages.mockResolvedValue({ data: [] });
         renderWithProviders(<TradeDetail />);
-        expect(await screen.findByRole('link', { name: 'TRK-ABC' })).toBeInTheDocument();
+        expect(await screen.findByText('TRK-ABC')).toBeInTheDocument();
         const shipped = await screen.findAllByText('Shipped');
         expect(shipped.length).toBeGreaterThan(0);
     });

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -192,8 +192,15 @@ describe('TradeDetail page', () => {
 
         expect(await screen.findByText('You: shipped. Partner: shipped.')).toBeInTheDocument();
 
-        expect(screen.getByText('1Z999AA10123456784')).toBeInTheDocument();
-        expect(screen.getByText('9400100000000000000000')).toBeInTheDocument();
+        const upsLink = screen.getByRole('link', { name: '1Z999AA10123456784' });
+        expect(upsLink).toHaveAttribute('href', 'https://www.ups.com/track?tracknum=1Z999AA10123456784');
+        expect(upsLink).toHaveAttribute('target', '_blank');
+        expect(upsLink).toHaveAttribute('rel', 'noopener noreferrer');
+
+        const uspsLink = screen.getByRole('link', { name: '9400100000000000000000' });
+        expect(uspsLink).toHaveAttribute('href', 'https://tools.usps.com/go/TrackConfirmAction?tLabels=9400100000000000000000');
+        expect(uspsLink).toHaveAttribute('target', '_blank');
+        expect(uspsLink).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
     it('falls back to web search for unknown tracking format', async () => {
@@ -222,7 +229,10 @@ describe('TradeDetail page', () => {
 
         renderWithProviders(<TradeDetail />);
 
-        expect(await screen.findByText('MY-CUSTOM-TRACKING')).toBeInTheDocument();
+        const fallbackLink = await screen.findByRole('link', { name: 'MY-CUSTOM-TRACKING' });
+        expect(fallbackLink).toHaveAttribute('href', 'https://www.google.com/search?q=MY-CUSTOM-TRACKING');
+        expect(fallbackLink).toHaveAttribute('target', '_blank');
+        expect(fallbackLink).toHaveAttribute('rel', 'noopener noreferrer');
     });
 
     it('shows one-sided shipped tracking when shipment uses camelCase fields', async () => {


### PR DESCRIPTION
## Summary
- replace the individual Trade page shipping badge copy with per-party shipment stage text
- show status from each viewer's perspective across confirmed, shipping, one-received, and completed stages
- add frontend lifecycle tests for both parties on the Trade detail page at every major shipping stage

## Bug
The Trade detail badge still rendered tracking-centric text like `You shipped (You: N/A, Partner: N/A)` when only one side had shipped. That wording was both misleading and not aligned with the desired user-facing behavior.

## Fix
The Trade detail badge now summarizes stage state directly:
- `You: not yet shipped. Partner: not yet shipped.`
- `You: shipped. Partner: not yet shipped.`
- `You: shipped. Partner: shipped.`
- `You: received. Partner: shipped.`
- `You: received. Partner: received.`

## Tests
- `npm run test:run -- src/pages/TradeDetail.test.jsx`
- `npm run test:run -- src/adapters/trades.test.js src/pages/TradeDetail.test.jsx`