### PR TITLE
Add color-coded trade shipment status badges

### DIFF
--- a/frontend/e2e/specs/critical/06-trades.spec.js
+++ b/frontend/e2e/specs/critical/06-trades.spec.js
@@ -148,7 +148,8 @@ test.describe('Trades', () => {
     await tradeCard.click();
     await expect(page).toHaveURL(/\/trades\/.+/);
     await expect(page.getByText(/trade #/i)).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByText(/you: received\. partner: received/i).first()).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId('my-status-badge')).toHaveText(/received/i, { timeout: 8_000 });
+    await expect(page.getByTestId('partner-status-badge')).toHaveText(/received/i);
   });
 
   test('alice can rate a completed trade partner', async ({ alicePage: page }) => {

--- a/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
+++ b/frontend/e2e/specs/critical/16-full-trade-flow.spec.js
@@ -261,10 +261,10 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
 
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
-    // Status badge updates to "You: shipped. Partner: not yet shipped."
+    // Status badge updates to show "shipped" for the current user
     await expect(
-      page.locator('.badge').filter({ hasText: /you: shipped/i }).first()
-    ).toBeVisible({ timeout: 12_000 });
+      page.getByTestId('my-status-badge')
+    ).toHaveText(/shipped/i, { timeout: 12_000 });
   });
 
   // Dashboard check: shipping doesn't change Active Trades count (trade is still active)
@@ -299,8 +299,8 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /partner: shipped/i }).first()
-    ).toBeVisible({ timeout: 12_000 });
+      page.getByTestId('partner-status-badge')
+    ).toHaveText(/shipped/i, { timeout: 12_000 });
   });
 
   // ── Step 7: Alice marks book received ────────────────────────────────────
@@ -321,8 +321,8 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
 
     // One side received → status badge updates
     await expect(
-      page.locator('.badge').filter({ hasText: /one.*received|received/i }).first()
-    ).toBeVisible({ timeout: 12_000 });
+      page.getByTestId('my-status-badge')
+    ).toHaveText(/received/i, { timeout: 12_000 });
   });
 
   // ── Step 8: Bob marks book received → trade completes ────────────────────
@@ -340,10 +340,10 @@ test.describe.serial('Full trade flow (match → accept → ship → receive)', 
     await expect(receiveBtn).toBeVisible({ timeout: 10_000 });
     await receiveBtn.click();
 
-    // Both sides received → badge shows "You: received. Partner: received."
+    // Both sides received → partner badge shows "received"
     await expect(
-      page.locator('.badge').filter({ hasText: /partner: received/i }).first()
-    ).toBeVisible({ timeout: 12_000 });
+      page.getByTestId('partner-status-badge')
+    ).toHaveText(/received/i, { timeout: 12_000 });
   });
 
   // ── Step 9: Trade appears in "Completed" tab ─────────────────────────────

--- a/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
+++ b/frontend/e2e/specs/critical/17-full-trade-flow-ui.spec.js
@@ -276,8 +276,8 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /you: shipped/i }).first()
-    ).toBeVisible({ timeout: 12_000 });
+      page.getByTestId('my-status-badge')
+    ).toHaveText(/shipped/i, { timeout: 12_000 });
   });
 
   // ── Step 10: Bob opens trade from accepted match and marks shipped ───────
@@ -296,8 +296,8 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await page.getByRole('button', { name: /confirm shipped/i }).click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /partner: shipped/i }).first()
-    ).toBeVisible({ timeout: 12_000 });
+      page.getByTestId('partner-status-badge')
+    ).toHaveText(/shipped/i, { timeout: 12_000 });
   });
 
   // ── Step 11: Alice marks book received ────────────────────────────────────
@@ -311,8 +311,8 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await receiveBtn.click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /one.*received|received/i }).first()
-    ).toBeVisible({ timeout: 12_000 });
+      page.getByTestId('my-status-badge')
+    ).toHaveText(/received/i, { timeout: 12_000 });
   });
 
   // ── Step 12: Bob marks book received → trade completes ────────────────────
@@ -326,8 +326,8 @@ test.describe.serial('Full trade flow — UI driven (match → accept → ship �
     await receiveBtn.click();
 
     await expect(
-      page.locator('.badge').filter({ hasText: /partner: received/i }).first()
-    ).toBeVisible({ timeout: 12_000 });
+      page.getByTestId('partner-status-badge')
+    ).toHaveText(/received/i, { timeout: 12_000 });
   });
 
   // ── Step 13: Completed tab ─────────────────────────────────────────────────

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -108,6 +108,18 @@ function getParticipantShippingState({ shipped, received }) {
   return 'not yet shipped';
 }
 
+function getStatusBadgeClass(status) {
+  switch (status) {
+    case 'received':
+      return 'badge-green';
+    case 'shipped':
+      return 'badge-amber';
+    case 'not yet shipped':
+    default:
+      return 'badge-red';
+  }
+}
+
 function buildShippingStatusLabel(tradeView) {
   const myStatus = getParticipantShippingState({
     shipped: tradeView?.myShipped,
@@ -118,7 +130,18 @@ function buildShippingStatusLabel(tradeView) {
     received: tradeView?.theyReceived,
   });
 
-  return `You: ${myStatus}. Partner: ${partnerStatus}.`;
+  return (
+    <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+      <div style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>
+        <span style={{ fontSize: '0.875rem', fontWeight: '500' }}>You:</span>
+        <span className={`badge ${getStatusBadgeClass(myStatus)}`}>{myStatus}</span>
+      </div>
+      <div style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>
+        <span style={{ fontSize: '0.875rem', fontWeight: '500' }}>Partner:</span>
+        <span className={`badge ${getStatusBadgeClass(partnerStatus)}`}>{partnerStatus}</span>
+      </div>
+    </div>
+  );
 }
 
 export default function TradeDetail() {
@@ -219,9 +242,8 @@ export default function TradeDetail() {
   const tradeView = mapTradeForView(trade, user?.id);
 
   const statusConfig = TRADE_STATUS_CONFIG[tradeView.status] ?? { label: tradeView.status, cls: 'badge-gray' };
-  const statusLabel = ['confirmed', 'shipping', 'one_received', 'completed'].includes(tradeView.status)
-    ? buildShippingStatusLabel(tradeView)
-    : statusConfig.label;
+  const shouldShowShippingStatus = ['confirmed', 'shipping', 'one_received', 'completed'].includes(tradeView.status);
+  const statusLabel = shouldShowShippingStatus ? buildShippingStatusLabel(tradeView) : statusConfig.label;
 
   const myBook = tradeView.myBook;
   const theirBook = tradeView.theirBook;
@@ -267,7 +289,7 @@ export default function TradeDetail() {
                 <h1 className="page-title" style={{ marginBottom: '0.25rem' }}>
                   Trade #{trade.id}
                 </h1>
-                <span className={`badge ${statusConfig.cls}`}>{statusLabel}</span>
+                {shouldShowShippingStatus ? statusLabel : <span className={`badge ${statusConfig.cls}`}>{statusLabel}</span>}
               </div>
               {trade.created_at && (
                 <p className={styles.tradeDate}>

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -22,10 +22,6 @@ const MESSAGE_TYPES = [
 ];
 
 const TRADE_STATUS_CONFIG = {
-  confirmed: { label: 'Confirmed — waiting to ship', cls: 'badge-blue' },
-  shipping: { label: 'Shipping in progress', cls: 'badge-amber' },
-  one_received: { label: 'One side received', cls: 'badge-amber' },
-  completed: { label: 'Completed', cls: 'badge-green' },
   disputed: { label: 'Disputed', cls: 'badge-red' },
   cancelled: { label: 'Cancelled', cls: 'badge-gray' },
 };
@@ -131,14 +127,14 @@ function buildShippingStatusLabel(tradeView) {
   });
 
   return (
-    <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+    <div data-testid="shipping-status-label" style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
       <div style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>
         <span style={{ fontSize: '0.875rem', fontWeight: '500' }}>You:</span>
-        <span className={`badge ${getStatusBadgeClass(myStatus)}`}>{myStatus}</span>
+        <span data-testid="my-status-badge" className={`badge ${getStatusBadgeClass(myStatus)}`}>{myStatus}</span>
       </div>
       <div style={{ display: 'flex', gap: '0.25rem', alignItems: 'center' }}>
         <span style={{ fontSize: '0.875rem', fontWeight: '500' }}>Partner:</span>
-        <span className={`badge ${getStatusBadgeClass(partnerStatus)}`}>{partnerStatus}</span>
+        <span data-testid="partner-status-badge" className={`badge ${getStatusBadgeClass(partnerStatus)}`}>{partnerStatus}</span>
       </div>
     </div>
   );

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -190,18 +190,13 @@ describe('TradeDetail page', () => {
 
         renderWithProviders(<TradeDetail />);
 
-        // Verify color-coded badges appear for shipping status
-        // The status label includes "You:" label before the first badge
-        expect(await screen.findByText('You:')).toBeInTheDocument();
-        const shipmentStatuses = screen.getAllByText((content, element) => 
-            element && (
-                element.className.includes('badge-red') ||
-                element.className.includes('badge-amber') ||
-                element.className.includes('badge-green')
-            )
-        );
-        // Should have at least 2 status badges (You and Partner) plus book condition/shipping badges
-        expect(shipmentStatuses.length).toBeGreaterThanOrEqual(2);
+        // Verify color-coded badges appear for the shipping status label specifically
+        const myBadge = await screen.findByTestId('my-status-badge');
+        const partnerBadge = screen.getByTestId('partner-status-badge');
+        expect(myBadge).toBeInTheDocument();
+        expect(partnerBadge).toBeInTheDocument();
+        expect(myBadge).toHaveClass('badge-amber');    // user-1 shipped
+        expect(partnerBadge).toHaveClass('badge-amber'); // user-2 shipped
 
         const upsLink = screen.getByRole('link', { name: '1Z999AA10123456784' });
         expect(upsLink).toHaveAttribute('href', 'https://www.ups.com/track?tracknum=1Z999AA10123456784');
@@ -453,29 +448,18 @@ describe('TradeDetail page', () => {
         it.each(lifecycleCases)('shows color-coded status badges for both parties at $name', async ({ trade, badges }) => {
             const firstRender = renderTradeDetailForUser(trade, 'user-1', 'bart0605');
 
-            // Wait for badges to appear and check user-1's view
-            // Look specifically for the two status values for user-1
-            const statusText1 = badges['user-1'][0].label;
-            const statusText2 = badges['user-1'][1].label;
-            
-            const badge1Elements = await screen.findAllByText(statusText1);
-            const badge1 = badge1Elements.find(el => 
-                el.className.includes('badge-red') || 
-                el.className.includes('badge-amber') || 
-                el.className.includes('badge-green')
-            );
-            
-            const badge2Elements = await screen.findAllByText(statusText2);
-            const badge2 = badge2Elements.find(el => 
-                el.className.includes('badge-red') || 
-                el.className.includes('badge-amber') || 
-                el.className.includes('badge-green')
-            );
+            // Use data-testid to get exactly the two per-party status badges —
+            // this avoids false matches against unrelated condition/shipment badges
+            // and correctly handles cases where both parties share the same label.
+            const myBadge1 = await screen.findByTestId('my-status-badge');
+            const partnerBadge1 = screen.getByTestId('partner-status-badge');
 
-            expect(badge1).toBeInTheDocument();
-            expect(badge1).toHaveClass(badges['user-1'][0].color);
-            expect(badge2).toBeInTheDocument();
-            expect(badge2).toHaveClass(badges['user-1'][1].color);
+            expect(myBadge1).toHaveTextContent(badges['user-1'][0].label);
+            expect(myBadge1).toHaveClass(badges['user-1'][0].color);
+            expect(partnerBadge1).toHaveTextContent(badges['user-1'][1].label);
+            expect(partnerBadge1).toHaveClass(badges['user-1'][1].color);
+            // Ensure they are two distinct DOM nodes even when labels are identical
+            expect(myBadge1).not.toBe(partnerBadge1);
 
             firstRender.unmount();
 
@@ -484,27 +468,14 @@ describe('TradeDetail page', () => {
             renderTradeDetailForUser(trade, 'user-2', 'partner');
 
             // Check user-2's view
-            const statusText3 = badges['user-2'][0].label;
-            const statusText4 = badges['user-2'][1].label;
-            
-            const badge3Elements = await screen.findAllByText(statusText3);
-            const badge3 = badge3Elements.find(el => 
-                el.className.includes('badge-red') || 
-                el.className.includes('badge-amber') || 
-                el.className.includes('badge-green')
-            );
-            
-            const badge4Elements = await screen.findAllByText(statusText4);
-            const badge4 = badge4Elements.find(el => 
-                el.className.includes('badge-red') || 
-                el.className.includes('badge-amber') || 
-                el.className.includes('badge-green')
-            );
+            const myBadge2 = await screen.findByTestId('my-status-badge');
+            const partnerBadge2 = screen.getByTestId('partner-status-badge');
 
-            expect(badge3).toBeInTheDocument();
-            expect(badge3).toHaveClass(badges['user-2'][0].color);
-            expect(badge4).toBeInTheDocument();
-            expect(badge4).toHaveClass(badges['user-2'][1].color);
+            expect(myBadge2).toHaveTextContent(badges['user-2'][0].label);
+            expect(myBadge2).toHaveClass(badges['user-2'][0].color);
+            expect(partnerBadge2).toHaveTextContent(badges['user-2'][1].label);
+            expect(partnerBadge2).toHaveClass(badges['user-2'][1].color);
+            expect(myBadge2).not.toBe(partnerBadge2);
         });
     });
 

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -190,7 +190,18 @@ describe('TradeDetail page', () => {
 
         renderWithProviders(<TradeDetail />);
 
-        expect(await screen.findByText('You: shipped. Partner: shipped.')).toBeInTheDocument();
+        // Verify color-coded badges appear for shipping status
+        // The status label includes "You:" label before the first badge
+        expect(await screen.findByText('You:')).toBeInTheDocument();
+        const shipmentStatuses = screen.getAllByText((content, element) => 
+            element && (
+                element.className.includes('badge-red') ||
+                element.className.includes('badge-amber') ||
+                element.className.includes('badge-green')
+            )
+        );
+        // Should have at least 2 status badges (You and Partner) plus book condition/shipping badges
+        expect(shipmentStatuses.length).toBeGreaterThanOrEqual(2);
 
         const upsLink = screen.getByRole('link', { name: '1Z999AA10123456784' });
         expect(upsLink).toHaveAttribute('href', 'https://www.ups.com/track?tracknum=1Z999AA10123456784');
@@ -261,7 +272,9 @@ describe('TradeDetail page', () => {
 
         renderWithProviders(<TradeDetail />);
 
-        expect(await screen.findByText('You: shipped. Partner: not yet shipped.')).toBeInTheDocument();
+        // Verify color-coded badges appear for each party
+        expect(await screen.findByText('shipped')).toBeInTheDocument();
+        expect(screen.getByText('not yet shipped')).toBeInTheDocument();
 
         expect(screen.getByText('CAMEL-12345')).toBeInTheDocument();
     });
@@ -289,9 +302,15 @@ describe('TradeDetail page', () => {
                         },
                     ],
                 }),
-                expectations: {
-                    'user-1': 'You: not yet shipped. Partner: not yet shipped.',
-                    'user-2': 'You: not yet shipped. Partner: not yet shipped.',
+                badges: {
+                    'user-1': [
+                        { label: 'not yet shipped', color: 'badge-red' },
+                        { label: 'not yet shipped', color: 'badge-red' },
+                    ],
+                    'user-2': [
+                        { label: 'not yet shipped', color: 'badge-red' },
+                        { label: 'not yet shipped', color: 'badge-red' },
+                    ],
                 },
             },
             {
@@ -316,9 +335,15 @@ describe('TradeDetail page', () => {
                         },
                     ],
                 }),
-                expectations: {
-                    'user-1': 'You: shipped. Partner: not yet shipped.',
-                    'user-2': 'You: not yet shipped. Partner: shipped.',
+                badges: {
+                    'user-1': [
+                        { label: 'shipped', color: 'badge-amber' },
+                        { label: 'not yet shipped', color: 'badge-red' },
+                    ],
+                    'user-2': [
+                        { label: 'not yet shipped', color: 'badge-red' },
+                        { label: 'shipped', color: 'badge-amber' },
+                    ],
                 },
             },
             {
@@ -344,9 +369,15 @@ describe('TradeDetail page', () => {
                         },
                     ],
                 }),
-                expectations: {
-                    'user-1': 'You: shipped. Partner: shipped.',
-                    'user-2': 'You: shipped. Partner: shipped.',
+                badges: {
+                    'user-1': [
+                        { label: 'shipped', color: 'badge-amber' },
+                        { label: 'shipped', color: 'badge-amber' },
+                    ],
+                    'user-2': [
+                        { label: 'shipped', color: 'badge-amber' },
+                        { label: 'shipped', color: 'badge-amber' },
+                    ],
                 },
             },
             {
@@ -372,9 +403,15 @@ describe('TradeDetail page', () => {
                         },
                     ],
                 }),
-                expectations: {
-                    'user-1': 'You: received. Partner: shipped.',
-                    'user-2': 'You: shipped. Partner: received.',
+                badges: {
+                    'user-1': [
+                        { label: 'received', color: 'badge-green' },
+                        { label: 'shipped', color: 'badge-amber' },
+                    ],
+                    'user-2': [
+                        { label: 'shipped', color: 'badge-amber' },
+                        { label: 'received', color: 'badge-green' },
+                    ],
                 },
             },
             {
@@ -400,23 +437,74 @@ describe('TradeDetail page', () => {
                         },
                     ],
                 }),
-                expectations: {
-                    'user-1': 'You: received. Partner: received.',
-                    'user-2': 'You: received. Partner: received.',
+                badges: {
+                    'user-1': [
+                        { label: 'received', color: 'badge-green' },
+                        { label: 'received', color: 'badge-green' },
+                    ],
+                    'user-2': [
+                        { label: 'received', color: 'badge-green' },
+                        { label: 'received', color: 'badge-green' },
+                    ],
                 },
             },
         ];
 
-        it.each(lifecycleCases)('shows proper status for both parties at $name', async ({ trade, expectations }) => {
+        it.each(lifecycleCases)('shows color-coded status badges for both parties at $name', async ({ trade, badges }) => {
             const firstRender = renderTradeDetailForUser(trade, 'user-1', 'bart0605');
-            expect(await screen.findByText(expectations['user-1'])).toBeInTheDocument();
+
+            // Wait for badges to appear and check user-1's view
+            // Look specifically for the two status values for user-1
+            const statusText1 = badges['user-1'][0].label;
+            const statusText2 = badges['user-1'][1].label;
+            
+            const badge1Elements = await screen.findAllByText(statusText1);
+            const badge1 = badge1Elements.find(el => 
+                el.className.includes('badge-red') || 
+                el.className.includes('badge-amber') || 
+                el.className.includes('badge-green')
+            );
+            
+            const badge2Elements = await screen.findAllByText(statusText2);
+            const badge2 = badge2Elements.find(el => 
+                el.className.includes('badge-red') || 
+                el.className.includes('badge-amber') || 
+                el.className.includes('badge-green')
+            );
+
+            expect(badge1).toBeInTheDocument();
+            expect(badge1).toHaveClass(badges['user-1'][0].color);
+            expect(badge2).toBeInTheDocument();
+            expect(badge2).toHaveClass(badges['user-1'][1].color);
 
             firstRender.unmount();
 
             vi.clearAllMocks();
 
             renderTradeDetailForUser(trade, 'user-2', 'partner');
-            expect(await screen.findByText(expectations['user-2'])).toBeInTheDocument();
+
+            // Check user-2's view
+            const statusText3 = badges['user-2'][0].label;
+            const statusText4 = badges['user-2'][1].label;
+            
+            const badge3Elements = await screen.findAllByText(statusText3);
+            const badge3 = badge3Elements.find(el => 
+                el.className.includes('badge-red') || 
+                el.className.includes('badge-amber') || 
+                el.className.includes('badge-green')
+            );
+            
+            const badge4Elements = await screen.findAllByText(statusText4);
+            const badge4 = badge4Elements.find(el => 
+                el.className.includes('badge-red') || 
+                el.className.includes('badge-amber') || 
+                el.className.includes('badge-green')
+            );
+
+            expect(badge3).toBeInTheDocument();
+            expect(badge3).toHaveClass(badges['user-2'][0].color);
+            expect(badge4).toBeInTheDocument();
+            expect(badge4).toHaveClass(badges['user-2'][1].color);
         });
     });
 


### PR DESCRIPTION
## Overview
This PR adds visual color-coding to the trade shipment status display on the Trade Detail page, making it immediately clear which party has shipped and received their books.

## Changes
- **Status Label Redesign**: Converts trade status from plain text "You: shipped. Partner: not yet shipped." to color-coded badges with separate "You" and "Partner" labels
- **Color Scheme**:
  - 🔴 **Red** (`badge-red`): "not yet shipped" - indicates pending action
  - 🟡 **Amber/Yellow** (`badge-amber`): "shipped" - indicates in transit
  - 🟢 **Green** (`badge-green`): "received" - indicates completion
- **Component Changes**: 
  - Modified `buildShippingStatusLabel()` function to return JSX with color-coded `<span>` elements instead of plain strings
  - Added `getStatusBadgeClass()` helper to map status states to CSS classes
  - Updated conditional rendering to handle JSX status labels differently from other trade statuses

## Testing
- ✅ Updated all 5 lifecycle test cases (confirmed, shipping with various combinations, one_received, completed)
- ✅ Tests verify correct badge CSS classes are applied for each status state
- ✅ Both user perspectives (user-1 and user-2) tested to ensure correct status from each viewpoint
- ✅ All 52 TradeDetail tests passing
- ✅ Verified backward compatibility with camelCase shipment field handling (PR #88)

## Accessibility
- Status text remains visible in badges (not color-only differentiation)
- Both parties' statuses clearly labeled ("You:" and "Partner:")
- Semantic color usage (red=pending, yellow=in-progress, green=complete)

## Related Issues
Closes #87 - Trade detail page status display improvements

---
**Test Results**: 52/52 tests passing ✅