### PR TITLE
Show proposer rating on proposal cards

### DIFF
--- a/frontend/src/pages/Proposals.jsx
+++ b/frontend/src/pages/Proposals.jsx
@@ -146,11 +146,25 @@ export default function Proposals() {
                       {proposer && (
                         <span className={styles.userLabel}>
                           From: <a href={`/profile/${proposer.id}`}>@{proposer.username}</a>
+                          {proposer.avg_recent_rating && (
+                            <Tooltip content="Average rating across their last 10 completed trades. Visible on their public profile.">
+                              <span className={styles.partnerRating}>
+                                {' '}&bull; {Number(proposer.avg_recent_rating).toFixed(1)} ★
+                              </span>
+                            </Tooltip>
+                          )}
                         </span>
                       )}
                       {receiver && (
                         <span className={styles.userLabel}>
                           To: <a href={`/profile/${receiver.id}`}>@{receiver.username}</a>
+                          {receiver.avg_recent_rating && (
+                            <Tooltip content="Average rating across their last 10 completed trades. Visible on their public profile.">
+                              <span className={styles.partnerRating}>
+                                {' '}&bull; {Number(receiver.avg_recent_rating).toFixed(1)} ★
+                              </span>
+                            </Tooltip>
+                          )}
                         </span>
                       )}
                     </div>

--- a/frontend/src/pages/Proposals.module.css
+++ b/frontend/src/pages/Proposals.module.css
@@ -193,3 +193,8 @@
   max-width: 440px;
   margin: 0 auto;
 }
+
+.partnerRating {
+  color: var(--color-warning);
+  font-size: 0.8125rem;
+}


### PR DESCRIPTION
## Summary

- Display `avg_recent_rating` next to the proposer/receiver username on each proposal card, matching the existing behavior on the Matches page
- The data was already returned by the API (`UserPublicProfileSerializer` includes `avg_recent_rating`) but was not rendered in the Proposals UI
- Added the `.partnerRating` CSS class to `Proposals.module.css` (amber color, consistent with Matches page styling)

## Test plan

- [ ] View a received proposal from a user who has ratings — confirm their rating appears as `• 4.5 ★` next to their username
- [ ] Hover the rating — confirm tooltip reads "Average rating across their last 10 completed trades. Visible on their public profile."
- [ ] View a proposal from a user with no ratings — confirm no rating text appears (graceful absence)
- [ ] View a sent proposal — confirm the recipient's rating is shown next to their "To:" username
- [ ] Confirm Matches page rating display is unchanged

https://claude.ai/code/session_01AqtLyC6cHgKFKghKLDzyFe

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqtLyC6cHgKFKghKLDzyFe)_