### PR TITLE
fix(e2e): resolve strict mode violation in public profile tests

### DIFF
--- a/frontend/e2e/specs/critical/12-public-profile.spec.js
+++ b/frontend/e2e/specs/critical/12-public-profile.spec.js
@@ -50,9 +50,10 @@ test.describe('Public Profile', () => {
 
     await expect(page.getByRole('heading', { name: /offered books/i })).toBeVisible({ timeout: 8_000 });
     // Alice has 3 seeded books — at least one should appear
+    const section = page.getByTestId('offered-books-section');
     await expect(
-      page.locator('[class*="wantedItem"]').first()
-        .or(page.getByText(/no books offered yet/i))
+      section.getByTestId('offered-book-item').first()
+        .or(section.getByText(/no books offered yet/i))
     ).toBeVisible({ timeout: 8_000 });
   });
 
@@ -62,6 +63,11 @@ test.describe('Public Profile', () => {
     await expect(page.getByRole('heading', { name: /^@alice_e2e$/i })).toBeVisible({ timeout: 15_000 });
 
     await expect(page.getByRole('heading', { name: /wanted books/i })).toBeVisible({ timeout: 8_000 });
+    const section = page.getByTestId('wanted-books-section');
+    await expect(
+      section.getByTestId('wanted-book-item').first()
+        .or(section.getByText(/no wanted books listed/i))
+    ).toBeVisible({ timeout: 8_000 });
   });
 
   test('profile has Recent Ratings section', async ({ alicePage: page }) => {
@@ -70,9 +76,10 @@ test.describe('Public Profile', () => {
     await expect(page.getByRole('heading', { name: /^@alice_e2e$/i })).toBeVisible({ timeout: 15_000 });
 
     await expect(page.getByRole('heading', { name: /recent ratings/i })).toBeVisible({ timeout: 8_000 });
+    const section = page.getByTestId('recent-ratings-section');
     await expect(
-      page.locator('[class*="ratingItem"]').first()
-        .or(page.getByText(/no ratings yet/i))
+      section.getByTestId('rating-item').first()
+        .or(section.getByText(/no ratings yet/i))
     ).toBeVisible({ timeout: 8_000 });
   });
 
@@ -94,9 +101,10 @@ test.describe('Public Profile', () => {
     await expect(page).toHaveURL(/\/profile\//);
 
     await expect(page.getByRole('heading', { name: /wanted books/i })).toBeVisible({ timeout: 8_000 });
+    const section = page.getByTestId('wanted-books-section');
     await expect(
-      page.locator('[class*="wantedItem"]').first()
-        .or(page.getByText(/no wanted books listed/i))
+      section.getByTestId('wanted-book-item').first()
+        .or(section.getByText(/no wanted books listed/i))
     ).toBeVisible({ timeout: 8_000 });
   });
 

--- a/frontend/src/pages/PublicProfile.jsx
+++ b/frontend/src/pages/PublicProfile.jsx
@@ -327,14 +327,14 @@ export default function PublicProfile() {
         )}
 
         {/* Ratings */}
-        <div className={`card ${styles.section}`}>
+        <div className={`card ${styles.section}`} data-testid="recent-ratings-section">
           <h2 className={styles.sectionTitle}>Recent Ratings</h2>
           {ratings.length === 0 ? (
             <p className={styles.emptyText}>No ratings yet.</p>
           ) : (
             <div className={styles.ratingList}>
               {ratings.map((rating, i) => (
-                <div key={rating.id ?? i} className={styles.ratingItem}>
+                <div key={rating.id ?? i} className={styles.ratingItem} data-testid="rating-item">
                   <div className={styles.ratingHeader}>
                     <div className={styles.ratingStars}>
                       {[1, 2, 3, 4, 5].map((star) => (
@@ -371,7 +371,7 @@ export default function PublicProfile() {
 
         {/* Institution wanted books */}
         {isInstitution && (
-          <div className={`card ${styles.section}`}>
+          <div className={`card ${styles.section}`} data-testid="wanted-books-section">
             <h2 className={styles.sectionTitle}>Wanted Books</h2>
             <p className={styles.sectionSubtitle}>
               This institution is looking for these books as donations or trades.
@@ -383,7 +383,7 @@ export default function PublicProfile() {
                 {wantedBooks.map((item, i) => {
                   const book = item.book ?? item;
                   return (
-                    <div key={item.id ?? i} className={styles.wantedItem}>
+                    <div key={item.id ?? i} className={styles.wantedItem} data-testid="wanted-book-item">
                       {getBookCoverUrl(book) && (
                         <img src={getBookCoverUrl(book)} alt={book.title} className={styles.wantedCover} />
                       )}
@@ -413,7 +413,7 @@ export default function PublicProfile() {
         )}
 
         {/* Offered books (all users) */}
-        <div className={`card ${styles.section}`}>
+        <div className={`card ${styles.section}`} data-testid="offered-books-section">
           <h2 className={styles.sectionTitle}>Offered Books</h2>
           <p className={styles.sectionSubtitle}>
             Books this user is currently offering for trade.
@@ -425,7 +425,7 @@ export default function PublicProfile() {
               {offeredBooks.map((item, i) => {
                 const book = item.book ?? item;
                 return (
-                  <div key={item.id ?? i} className={styles.wantedItem}>
+                  <div key={item.id ?? i} className={styles.wantedItem} data-testid="offered-book-item">
                     {getBookCoverUrl(book) && (
                       <img src={getBookCoverUrl(book)} alt={book.title} className={styles.wantedCover} />
                     )}
@@ -450,7 +450,7 @@ export default function PublicProfile() {
 
         {/* Wanted books (non-institution users) */}
         {!isInstitution && (
-          <div className={`card ${styles.section}`}>
+          <div className={`card ${styles.section}`} data-testid="wanted-books-section">
             <h2 className={styles.sectionTitle}>Wanted Books</h2>
             <p className={styles.sectionSubtitle}>
               Books this user is looking to receive via trade.
@@ -462,7 +462,7 @@ export default function PublicProfile() {
                 {publicWantedBooks.map((item, i) => {
                   const book = item.book ?? item;
                   return (
-                    <div key={item.id ?? i} className={styles.wantedItem}>
+                    <div key={item.id ?? i} className={styles.wantedItem} data-testid="wanted-book-item">
                       {getBookCoverUrl(book) && (
                         <img src={getBookCoverUrl(book)} alt={book.title} className={styles.wantedCover} />
                       )}


### PR DESCRIPTION
This PR fixes a Playwright strict mode violation in the public profile E2E tests.

### Changes:
- Added `data-testid` attributes to major sections and items in `PublicProfile.jsx`.
- Updated `12-public-profile.spec.js` to use scoped locators via these `data-testid`s.
- This prevents locators from matching multiple elements when one section is empty but another contains similar items.

### Verification:
- Scoped locators are now unambiguous.
- Unit tests pass.
- Fixed the reported failure in CI.