### PR TITLE
Add About page to public routes and main navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,6 +20,7 @@ import TradeDetail from './pages/TradeDetail.jsx';
 import Donations from './pages/Donations.jsx';
 import PublicProfile from './pages/PublicProfile.jsx';
 import Institutions from './pages/Institutions.jsx';
+import About from './pages/About.jsx';
 import useAuth from './hooks/useAuth.js';
 import AppErrorBoundary from './components/AppErrorBoundary.jsx';
 
@@ -47,6 +48,7 @@ export default function App() {
         <Route element={<Layout />}>
           {/* Public routes */}
           <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
           <Route path="/institutions" element={<Institutions />} />
           <Route path="/profile/:id" element={<PublicProfile />} />
 

--- a/frontend/src/components/layout/Navbar.jsx
+++ b/frontend/src/components/layout/Navbar.jsx
@@ -87,6 +87,9 @@ export default function Navbar() {
           <NavLink to="/institutions" className={navLinkClass}>
             Institutions
           </NavLink>
+          <NavLink to="/about" className={navLinkClass}>
+            About
+          </NavLink>
           {isAuthenticated && (
             <>
               <NavLink to="/my-books" className={navLinkClass}>
@@ -272,6 +275,9 @@ export default function Navbar() {
           </NavLink>
           <NavLink to="/institutions" className={navLinkClass} onClick={() => setMobileOpen(false)}>
             Institutions
+          </NavLink>
+          <NavLink to="/about" className={navLinkClass} onClick={() => setMobileOpen(false)}>
+            About
           </NavLink>
           {isAuthenticated ? (
             <>


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Registers `/about` as a public route in `App.jsx` so it is accessible without logging in
- Adds an "About" link to the desktop nav bar (between Institutions and the auth area), always visible
- Adds an "About" link to the mobile hamburger menu, always visible

## Test plan

- [ ] Visit `/about` while logged out — page loads correctly
- [ ] Visit `/about` while logged in — page loads correctly
- [ ] "About" link appears in the desktop nav and highlights as active when on `/about`
- [ ] "About" link appears in the mobile menu and closes the menu on tap
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01An2ziGT5Jg4S82zYeBdVcM)_