### PR TITLE
Add Umami analytics integration with event tracking

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,9 @@
 # Development: leave blank to use the Vite proxy (proxies /api to localhost:8000)
 # Production:  https://api.bookforbook.com/api/v1
 VITE_API_URL=
+
+# Umami analytics — leave blank to disable (safe for local dev)
+# VITE_UMAMI_SRC=https://analytics.bookforbook.com/script.js
+# VITE_UMAMI_WEBSITE_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+VITE_UMAMI_SRC=
+VITE_UMAMI_WEBSITE_ID=

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -5,6 +5,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App.jsx';
 import './index.css';
 
+if (import.meta.env.VITE_UMAMI_SRC && import.meta.env.VITE_UMAMI_WEBSITE_ID) {
+  const script = document.createElement('script');
+  script.defer = true;
+  script.src = import.meta.env.VITE_UMAMI_SRC;
+  script.dataset.websiteId = import.meta.env.VITE_UMAMI_WEBSITE_ID;
+  document.head.appendChild(script);
+}
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {

--- a/frontend/src/pages/Matches.jsx
+++ b/frontend/src/pages/Matches.jsx
@@ -65,6 +65,7 @@ export default function Matches() {
   const acceptMutation = useMutation({
     mutationFn: (id) => matchesApi.accept(id),
     onSuccess: () => {
+      window.umami?.track('match_accepted');
       queryClient.invalidateQueries({ queryKey: ['matches'] });
       setActionError(null);
       setRequiresAddressVerification(false);

--- a/frontend/src/pages/MyBooks.jsx
+++ b/frontend/src/pages/MyBooks.jsx
@@ -57,6 +57,7 @@ export default function MyBooks() {
   const addMutation = useMutation({
     mutationFn: (bookData) => myBooksApi.add(bookData),
     onSuccess: (response) => {
+      window.umami?.track('book_added');
       // Fire background enrichment only after the add succeeds, so we don't
       // waste rate-limit budget or backend work when the add fails.
       const isbn = response?.data?.book?.isbn_13;

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -182,6 +182,7 @@ export default function TradeDetail() {
   const markReceivedMutation = useMutation({
     mutationFn: () => tradesApi.markReceived(id),
     onSuccess: () => {
+      window.umami?.track('trade_received');
       queryClient.invalidateQueries({ queryKey: ['trade', id] });
       setActionError(null);
     },

--- a/frontend/src/pages/Wishlist.jsx
+++ b/frontend/src/pages/Wishlist.jsx
@@ -128,6 +128,7 @@ export default function Wishlist() {
   const addMutation = useMutation({
     mutationFn: (itemData) => wishlistApi.add(itemData),
     onSuccess: (response) => {
+      window.umami?.track('wishlist_added');
       // Fire background enrichment only after the add succeeds, so we don't
       // waste rate-limit budget or backend work when the add fails.
       const isbn = response?.data?.book?.isbn_13;


### PR DESCRIPTION
## Summary
Integrates Umami analytics into the frontend with conditional script loading and event tracking for key user actions.

## Key Changes
- **Analytics script initialization** (`frontend/src/main.jsx`): Conditionally loads the Umami analytics script at app startup if both `VITE_UMAMI_SRC` and `VITE_UMAMI_WEBSITE_ID` environment variables are configured
- **Environment configuration** (`frontend/.env.example`): Added Umami-specific environment variables with commented examples and safe defaults (blank values disable analytics)
- **Event tracking**: Added `window.umami?.track()` calls for key user actions:
  - `match_accepted` in Matches page
  - `book_added` in MyBooks page
  - `trade_received` in TradeDetail page
  - `wishlist_added` in Wishlist page

## Implementation Details
- Script loading uses optional chaining (`window.umami?.track()`) to safely handle cases where Umami is not loaded or disabled
- Analytics is completely optional — leaving environment variables blank disables it without errors
- Safe for local development (no analytics overhead when not configured)
- Events are tracked on successful mutations, capturing meaningful user interactions

https://claude.ai/code/session_01KojnHfqZV5rRi79LsmJjBv