### PR TITLE
Enforce per-shipment penalties and rewards on trade auto-close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,4 @@ junit*.xml
 test-report*.xml
 
 superusers.jsondb_e2e.sqlite3
+.claude/

--- a/apps/notifications/email.py
+++ b/apps/notifications/email.py
@@ -122,6 +122,31 @@ def send_rating_reminder_email(user, trade) -> bool:
     return send_email(user.email, subject, text_body)
 
 
+def send_closure_warning_email(user, trade, reason: str) -> bool:
+    trade_url = f"{settings.FRONTEND_URL}/trades/{trade.pk}"
+    subject = "Action required: your BookForBook trade closes in 2 days"
+    if reason == "not_started":
+        detail = (
+            "Neither party has shipped yet. "
+            "If no shipment is recorded before the deadline, your book will be "
+            "returned to your available list and you will receive a 1-star review."
+        )
+    else:
+        detail = (
+            "No valid tracking number is on file for your shipment. "
+            "Please ship your book and enter the tracking number before the deadline "
+            "to avoid a 1-star review."
+        )
+    text_body = (
+        f"Hi {user.username},\n\n"
+        f"Your trade is closing in 2 days.\n\n"
+        f"{detail}\n\n"
+        f"View your trade here:\n{trade_url}\n\n"
+        f"— The BookForBook Team"
+    )
+    return send_email(user.email, subject, text_body)
+
+
 def send_inactivity_warning_1m_email(user) -> bool:
     subject = "We miss you on BookForBook!"
     text_body = (

--- a/apps/notifications/management/commands/run_periodic_tasks.py
+++ b/apps/notifications/management/commands/run_periodic_tasks.py
@@ -19,6 +19,9 @@ Crontab example:
     0 3 * * 0 /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=rating_reminders
     0 3 * * 0 /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=auto_close
 
+    # Daily — warn users approaching auto-close
+    0 4 * * * /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=trade_closure_warnings
+
     # Or run all at once (less granular):
     0 3 * * * /home/bookforbook/private/bookforbook/.venv/bin/python /home/bookforbook/private/bookforbook/manage.py run_periodic_tasks --task=all
 """
@@ -37,6 +40,7 @@ TASKS = {
     "account_deletions": "apps.notifications.tasks.finalize_scheduled_account_deletions",
     "rating_reminders": "apps.trading.tasks.send_rating_reminders",
     "auto_close": "apps.trading.tasks.auto_close_trades",
+    "trade_closure_warnings": "apps.trading.tasks.send_trade_closure_warnings",
 }
 
 

--- a/apps/notifications/tasks.py
+++ b/apps/notifications/tasks.py
@@ -297,6 +297,8 @@ def finalize_scheduled_account_deletions(grace_days: int = 30):
 
 def send_closure_warning(user_id: str, trade_id: str, reason: str):
     """Warn a user that their trade will auto-close within 2 days."""
+    from django.conf import settings
+
     user = get_user_or_warn(user_id, "send_closure_warning")
     if user is None:
         return
@@ -305,17 +307,21 @@ def send_closure_warning(user_id: str, trade_id: str, reason: str):
         return
 
     from apps.notifications.models import Notification
+    from apps.notifications.email import send_closure_warning_email
+
+    trade_url = f"{settings.FRONTEND_URL}/trades/{trade.pk}"
 
     if reason == "not_started":
         body = (
             "Your trade has not been shipped yet and will auto-close in 2 days. "
             "If no shipment is recorded, your book will be returned to your available list "
-            "and you will receive a 1-star review."
+            f"and you will receive a 1-star review. View your trade: {trade_url}"
         )
     else:
         body = (
             "Your trade will auto-close in 2 days and no valid tracking number is on file. "
-            "Please ship your book and enter a tracking number to avoid a 1-star review."
+            "Please ship your book and enter a tracking number to avoid a 1-star review. "
+            f"View your trade: {trade_url}"
         )
 
     Notification.objects.create(
@@ -325,6 +331,9 @@ def send_closure_warning(user_id: str, trade_id: str, reason: str):
         body=body,
         metadata={"trade_id": trade_id},
     )
+
+    send_closure_warning_email(user, trade, reason)
+
     logger.info("Sent closure warning to user %s for trade %s", user_id, trade_id)
 
 

--- a/apps/notifications/tasks.py
+++ b/apps/notifications/tasks.py
@@ -295,6 +295,39 @@ def finalize_scheduled_account_deletions(grace_days: int = 30):
         )
 
 
+def send_closure_warning(user_id: str, trade_id: str, reason: str):
+    """Warn a user that their trade will auto-close within 2 days."""
+    user = get_user_or_warn(user_id, "send_closure_warning")
+    if user is None:
+        return
+    trade = get_trade_or_warn(trade_id, "send_closure_warning")
+    if trade is None:
+        return
+
+    from apps.notifications.models import Notification
+
+    if reason == "not_started":
+        body = (
+            "Your trade has not been shipped yet and will auto-close in 2 days. "
+            "If no shipment is recorded, your book will be returned to your available list "
+            "and you will receive a 1-star review."
+        )
+    else:
+        body = (
+            "Your trade will auto-close in 2 days and no valid tracking number is on file. "
+            "Please ship your book and enter a tracking number to avoid a 1-star review."
+        )
+
+    Notification.objects.create(
+        user=user,
+        notification_type="trade_closure_warning",
+        title="Trade closing soon",
+        body=body,
+        metadata={"trade_id": trade_id},
+    )
+    logger.info("Sent closure warning to user %s for trade %s", user_id, trade_id)
+
+
 def check_inactivity():
     """
     Daily task: scan all users and send inactivity warnings / delist books.

--- a/apps/ratings/migrations/0002_alter_rating_unique_together.py
+++ b/apps/ratings/migrations/0002_alter_rating_unique_together.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ratings', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='rating',
+            unique_together={('trade', 'rater', 'rated')},
+        ),
+    ]

--- a/apps/ratings/models.py
+++ b/apps/ratings/models.py
@@ -35,7 +35,7 @@ class Rating(models.Model):
     class Meta:
         verbose_name = 'Rating'
         verbose_name_plural = 'Ratings'
-        unique_together = [('trade', 'rater')]
+        unique_together = [('trade', 'rater', 'rated')]
         ordering = ['-created_at']
 
     def __str__(self):

--- a/apps/ratings/tests/test_ratings.py
+++ b/apps/ratings/tests/test_ratings.py
@@ -154,3 +154,36 @@ class TestRatingUnique:
 
         with pytest.raises(IntegrityError):
             _make_rating(trade, a, b, 3)
+
+
+class TestRatingUniqueWithRated:
+    def test_trade_manager_can_rate_two_senders(self):
+        """Trade Manager can create two ratings on the same trade for different senders."""
+        from apps.accounts.models import User
+        trade_manager, _ = User.objects.get_or_create(
+            username="trademanager",
+            defaults={"email": "trademanager@system.internal", "is_active": False},
+        )
+        a = UserFactory()
+        b = UserFactory()
+        trade = _make_trade(a, b)
+
+        _make_rating(trade, trade_manager, a, 5)
+        _make_rating(trade, trade_manager, b, 5)  # should not raise
+
+        assert Rating.objects.filter(trade=trade, rater=trade_manager).count() == 2
+
+    def test_trade_manager_cannot_rate_same_sender_twice(self):
+        """Trade Manager cannot rate the same person twice on the same trade."""
+        from apps.accounts.models import User
+        trade_manager, _ = User.objects.get_or_create(
+            username="trademanager",
+            defaults={"email": "trademanager@system.internal", "is_active": False},
+        )
+        a = UserFactory()
+        b = UserFactory()
+        trade = _make_trade(a, b)
+
+        _make_rating(trade, trade_manager, a, 5)
+        with pytest.raises(IntegrityError):
+            _make_rating(trade, trade_manager, a, 1)

--- a/apps/trading/migrations/0003_add_trade_closure_warning_sent_at.py
+++ b/apps/trading/migrations/0003_add_trade_closure_warning_sent_at.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('trading', '0002_trade_trade_unique_source'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='trade',
+            name='closure_warning_sent_at',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/apps/trading/models.py
+++ b/apps/trading/models.py
@@ -105,6 +105,7 @@ class Trade(models.Model):
     completed_at = models.DateTimeField(null=True, blank=True)
     auto_close_at = models.DateTimeField(null=True, blank=True)
     rating_reminders_sent = models.PositiveIntegerField(default=0)
+    closure_warning_sent_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         verbose_name = "Trade"

--- a/apps/trading/serializers.py
+++ b/apps/trading/serializers.py
@@ -200,6 +200,13 @@ class MarkShippedSerializer(serializers.Serializer):
     tracking_number = serializers.CharField(required=False, allow_blank=True, max_length=100)
     shipping_method = serializers.CharField(required=False, allow_blank=True, max_length=100)
 
+    def validate_tracking_number(self, value):
+        from apps.trading.utils import is_valid_tracking_number
+        if value and not is_valid_tracking_number(value):
+            # Soft warning — not a hard error, stored as-is but flagged
+            self._tracking_unrecognized = True
+        return value
+
 
 class TradeRateSerializer(serializers.Serializer):
     rated_user_id = serializers.UUIDField()

--- a/apps/trading/tasks.py
+++ b/apps/trading/tasks.py
@@ -212,6 +212,15 @@ def send_trade_closure_warnings():
     ).prefetch_related("shipments")
 
     for trade in trades:
+        # Stamp the guard before queuing tasks so that a crash mid-loop
+        # does not cause re-warnings on retry for this trade.
+        updated = Trade.objects.filter(
+            pk=trade.pk, closure_warning_sent_at__isnull=True
+        ).update(closure_warning_sent_at=now)
+        if not updated:
+            # Another worker already claimed this trade.
+            continue
+
         if trade.status == Trade.Status.CONFIRMED:
             # Nothing shipped at all — warn all senders
             for shipment in trade.shipments.all():
@@ -247,9 +256,6 @@ def send_trade_closure_warnings():
                             trade.pk,
                             shipment.sender_id,
                         )
-
-        trade.closure_warning_sent_at = now
-        trade.save(update_fields=["closure_warning_sent_at"])
 
         logger.info("Queued closure warnings for trade %s", trade.pk)
 

--- a/apps/trading/tasks.py
+++ b/apps/trading/tasks.py
@@ -1,9 +1,25 @@
 import logging
 
 from django.db import transaction
+from django.db.models import F
 from django.utils import timezone
 
 logger = logging.getLogger(__name__)
+
+
+def _get_trade_manager():
+    from apps.accounts.models import User
+    user, created = User.objects.get_or_create(
+        username="trademanager",
+        defaults={
+            "email": "trademanager@system.internal",
+            "is_active": False,
+        },
+    )
+    if not created and user.is_active:
+        user.is_active = False
+        user.save(update_fields=["is_active"])
+    return user
 
 
 def send_rating_reminders():
@@ -11,11 +27,10 @@ def send_rating_reminders():
     Weekly task: send rating reminders to users who haven't rated yet.
     Sends up to 3 reminders per trade, then gives up.
     """
-    from apps.trading.models import Trade, TradeShipment
+    from apps.trading.models import Trade
     from apps.ratings.models import Rating
     from django_q.tasks import async_task
 
-    # Find completed/shipping trades that still need ratings
     active_statuses = [
         Trade.Status.COMPLETED,
         Trade.Status.SHIPPING,
@@ -27,13 +42,11 @@ def send_rating_reminders():
     ).prefetch_related("shipments__sender", "shipments__receiver")
 
     for trade in trades:
-        # Get all parties
         user_ids = set()
         for shipment in trade.shipments.all():
             user_ids.add(str(shipment.sender_id))
             user_ids.add(str(shipment.receiver_id))
 
-        # Find who hasn't rated yet
         rated_user_ids = set(
             str(uid)
             for uid in Rating.objects.filter(trade=trade).values_list(
@@ -65,80 +78,262 @@ def send_rating_reminders():
 def auto_close_trades():
     """
     Weekly task: close trades that have passed their auto_close_at deadline.
-    Marks books as traded, updates user counts, no rating recorded.
+
+    Per-shipment logic for SHIPPING / ONE_RECEIVED trades:
+      - Valid tracking or already RECEIVED  → 5-star auto-rating, book TRADED, both parties credited
+      - No valid tracking                   → 1-star auto-rating, book AVAILABLE, no credit
+    CONFIRMED trades (nothing shipped at all) → books restored, no ratings, no credit.
     """
     from apps.trading.models import Trade, TradeShipment
     from apps.inventory.models import UserBook
     from apps.accounts.models import User
-    from django.db.models import F
+    from apps.ratings.models import Rating
+    from apps.ratings.services.rolling_average import recompute_rating_average
+    from apps.trading.utils import is_valid_tracking_number
 
     now = timezone.now()
-    trades_to_close = Trade.objects.filter(
+
+    trades_to_close = (
+        Trade.objects.select_for_update(skip_locked=True)
+        .filter(
+            status__in=[
+                Trade.Status.CONFIRMED,
+                Trade.Status.SHIPPING,
+                Trade.Status.ONE_RECEIVED,
+            ],
+            auto_close_at__lt=now,
+        )
+        .prefetch_related("shipments__sender", "shipments__receiver", "shipments__user_book")
+    )
+
+    for trade in trades_to_close:
+        try:
+            all_shipments = list(trade.shipments.all())
+
+            with transaction.atomic():
+                if trade.status == Trade.Status.CONFIRMED:
+                    # Nothing was shipped — restore books, no credit, no ratings
+                    book_ids = [s.user_book_id for s in all_shipments]
+                    UserBook.objects.filter(pk__in=book_ids).update(
+                        status=UserBook.Status.AVAILABLE
+                    )
+                    _notify_confirmed_auto_close(trade, all_shipments)
+                else:
+                    # SHIPPING or ONE_RECEIVED — evaluate per shipment
+                    trade_manager = _get_trade_manager()
+
+                    for shipment in all_shipments:
+                        shipped_ok = (
+                            shipment.status == TradeShipment.Status.RECEIVED
+                            or (
+                                shipment.status
+                                in (TradeShipment.Status.PENDING, TradeShipment.Status.SHIPPED)
+                                and is_valid_tracking_number(shipment.tracking_number)
+                            )
+                        )
+
+                        if shipped_ok:
+                            if shipment.status != TradeShipment.Status.RECEIVED:
+                                shipment.status = TradeShipment.Status.RECEIVED
+                                shipment.received_at = now
+                                shipment.save(update_fields=["status", "received_at"])
+
+                            shipment.user_book.status = UserBook.Status.TRADED
+                            shipment.user_book.save(update_fields=["status"])
+
+                            User.objects.filter(
+                                pk__in=[shipment.sender_id, shipment.receiver_id]
+                            ).update(total_trades=F("total_trades") + 1)
+
+                            Rating.objects.create(
+                                trade=trade,
+                                rater=trade_manager,
+                                rated=shipment.sender,
+                                score=5,
+                                book_condition_accurate=True,
+                            )
+                            _notify_shipment_success(trade, shipment)
+                        else:
+                            shipment.status = TradeShipment.Status.NOT_RECEIVED
+                            shipment.save(update_fields=["status"])
+
+                            shipment.user_book.status = UserBook.Status.AVAILABLE
+                            shipment.user_book.save(update_fields=["status"])
+
+                            Rating.objects.create(
+                                trade=trade,
+                                rater=trade_manager,
+                                rated=shipment.sender,
+                                score=1,
+                                comment="Did not ship",
+                                book_condition_accurate=True,
+                            )
+                            _notify_shipment_failure(trade, shipment)
+
+                    # Recompute rolling averages inside the transaction
+                    for shipment in all_shipments:
+                        try:
+                            recompute_rating_average(shipment.sender)
+                        except Exception:
+                            logger.exception(
+                                "Failed to recompute rating for user %s", shipment.sender_id
+                            )
+
+                trade.status = Trade.Status.AUTO_CLOSED
+                trade.completed_at = now
+                trade.save(update_fields=["status", "completed_at"])
+
+            logger.info("Auto-closed trade %s", trade.pk)
+        except Exception:
+            logger.exception("Failed to auto-close trade %s", trade.pk)
+
+
+def send_trade_closure_warnings():
+    """
+    Daily task: warn users whose trade is within 2 days of auto-close and
+    who have not provided a valid tracking number.
+    """
+    from apps.trading.models import Trade, TradeShipment
+    from apps.trading.utils import is_valid_tracking_number
+    from django_q.tasks import async_task
+    from datetime import timedelta
+
+    now = timezone.now()
+    warning_window_end = now + timedelta(days=2)
+
+    trades = Trade.objects.filter(
         status__in=[
             Trade.Status.CONFIRMED,
             Trade.Status.SHIPPING,
             Trade.Status.ONE_RECEIVED,
         ],
-        auto_close_at__lt=now,
+        auto_close_at__range=(now, warning_window_end),
+        closure_warning_sent_at__isnull=True,
     ).prefetch_related("shipments")
 
-    for trade in trades_to_close:
-        try:
-            all_shipments = list(trade.shipments.all())
-            book_ids = [s.user_book_id for s in all_shipments]
-            user_ids = set()
-            for s in all_shipments:
-                user_ids.add(s.sender_id)
-                user_ids.add(s.receiver_id)
-
-            with transaction.atomic():
-                if trade.status == Trade.Status.CONFIRMED:
-                    # Nothing was shipped — restore books to available, don't count as a trade
-                    UserBook.objects.filter(pk__in=book_ids).update(
-                        status=UserBook.Status.AVAILABLE
-                    )
-                else:
-                    # Books are in transit (SHIPPING / ONE_RECEIVED) — treat as delivered
-                    TradeShipment.objects.filter(
-                        trade=trade,
-                        status__in=[
-                            TradeShipment.Status.PENDING,
-                            TradeShipment.Status.SHIPPED,
-                        ],
-                    ).update(
-                        status=TradeShipment.Status.RECEIVED,
-                        received_at=now,
-                    )
-                    UserBook.objects.filter(pk__in=book_ids).update(
-                        status=UserBook.Status.TRADED
-                    )
-                    User.objects.filter(pk__in=user_ids).update(
-                        total_trades=F("total_trades") + 1
-                    )
-
-                # Close trade
-                trade.status = Trade.Status.AUTO_CLOSED
-                trade.completed_at = now
-                trade.save(update_fields=["status", "completed_at"])
-
-            # Notify
-            for uid in user_ids:
+    for trade in trades:
+        if trade.status == Trade.Status.CONFIRMED:
+            # Nothing shipped at all — warn all senders
+            for shipment in trade.shipments.all():
                 try:
-                    from apps.notifications.models import Notification
-
-                    Notification.objects.create(
-                        user_id=uid,
-                        notification_type="trade_auto_closed",
-                        title="Trade auto-closed",
-                        body=(
-                            "Your trade has been automatically closed after 3 weeks. "
-                            "The book has been marked as received."
-                        ),
-                        metadata={"trade_id": str(trade.pk)},
+                    async_task(
+                        "apps.notifications.tasks.send_closure_warning",
+                        str(shipment.sender_id),
+                        str(trade.pk),
+                        "not_started",
                     )
                 except Exception:
-                    logger.exception("Failed to notify user %s of auto-close", uid)
+                    logger.exception(
+                        "Failed to queue closure warning for trade %s, user %s",
+                        trade.pk,
+                        shipment.sender_id,
+                    )
+        else:
+            # Warn only senders without valid tracking
+            for shipment in trade.shipments.filter(
+                status__in=[TradeShipment.Status.PENDING, TradeShipment.Status.SHIPPED]
+            ):
+                if not is_valid_tracking_number(shipment.tracking_number):
+                    try:
+                        async_task(
+                            "apps.notifications.tasks.send_closure_warning",
+                            str(shipment.sender_id),
+                            str(trade.pk),
+                            "no_tracking",
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to queue closure warning for trade %s, user %s",
+                            trade.pk,
+                            shipment.sender_id,
+                        )
 
-            logger.info("Auto-closed trade %s", trade.pk)
+        trade.closure_warning_sent_at = now
+        trade.save(update_fields=["closure_warning_sent_at"])
+
+        logger.info("Queued closure warnings for trade %s", trade.pk)
+
+
+# ---------------------------------------------------------------------------
+# Notification helpers
+# ---------------------------------------------------------------------------
+
+
+def _notify_confirmed_auto_close(trade, shipments):
+    sender_ids = {s.sender_id for s in shipments}
+    receiver_ids = {s.receiver_id for s in shipments}
+    all_ids = sender_ids | receiver_ids
+    _create_notifications(
+        trade,
+        all_ids,
+        "trade_auto_closed",
+        "Trade auto-closed",
+        "Your trade was auto-closed after 3 weeks. Neither party shipped, so your books have been returned to your available list.",
+    )
+
+
+def _notify_shipment_success(trade, shipment):
+    from apps.notifications.models import Notification
+
+    for user_id, msg in [
+        (
+            shipment.sender_id,
+            "Your trade has been auto-closed. Your book was marked as received and you've been credited with a 5-star review.",
+        ),
+        (
+            shipment.receiver_id,
+            "Your trade has been auto-closed. Your partner's book was marked as received.",
+        ),
+    ]:
+        try:
+            Notification.objects.create(
+                user_id=user_id,
+                notification_type="trade_auto_closed",
+                title="Trade auto-closed",
+                body=msg,
+                metadata={"trade_id": str(trade.pk)},
+            )
         except Exception:
-            logger.exception("Failed to auto-close trade %s", trade.pk)
+            logger.exception("Failed to notify user %s of auto-close", user_id)
+
+
+def _notify_shipment_failure(trade, shipment):
+    from apps.notifications.models import Notification
+
+    msgs = {
+        shipment.sender_id: (
+            "Your trade has been auto-closed. No valid tracking number was found for your shipment. "
+            "Your book has been returned to your available list and you have received a 1-star review."
+        ),
+        shipment.receiver_id: (
+            "Your trade has been auto-closed. The other party did not ship their book. "
+            "No trade credit has been recorded for that leg."
+        ),
+    }
+    for user_id, body in msgs.items():
+        try:
+            Notification.objects.create(
+                user_id=user_id,
+                notification_type="trade_auto_closed",
+                title="Trade auto-closed",
+                body=body,
+                metadata={"trade_id": str(trade.pk)},
+            )
+        except Exception:
+            logger.exception("Failed to notify user %s of auto-close", user_id)
+
+
+def _create_notifications(trade, user_ids, notification_type, title, body):
+    from apps.notifications.models import Notification
+
+    for uid in user_ids:
+        try:
+            Notification.objects.create(
+                user_id=uid,
+                notification_type=notification_type,
+                title=title,
+                body=body,
+                metadata={"trade_id": str(trade.pk)},
+            )
+        except Exception:
+            logger.exception("Failed to notify user %s", uid)

--- a/apps/trading/tests/test_trading_tasks.py
+++ b/apps/trading/tests/test_trading_tasks.py
@@ -1,15 +1,26 @@
 import pytest
 from datetime import timedelta
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
+from django.db import IntegrityError
 from django.utils import timezone
 
 from apps.tests.factories import UserFactory, TradeFactory, TradeShipmentFactory, RatingFactory, UserBookFactory
 from apps.trading.models import Trade, TradeShipment
-from apps.trading.tasks import send_rating_reminders, auto_close_trades
+from apps.trading.tasks import send_rating_reminders, auto_close_trades, send_trade_closure_warnings
 from apps.inventory.models import UserBook
+from apps.ratings.models import Rating
+
+
+def make_expired_trade(**kwargs):
+    """Create a trade with auto_close_at in the past."""
+    trade = TradeFactory(**kwargs)
+    Trade.objects.filter(pk=trade.pk).update(auto_close_at=timezone.now() - timedelta(days=1))
+    trade.refresh_from_db()
+    return trade
+
 
 @pytest.mark.django_db
-class TestTradingTasks:
+class TestSendRatingReminders:
     @patch("django_q.tasks.async_task")
     def test_send_rating_reminders(self, mock_async):
         user_a = UserFactory()
@@ -17,49 +28,284 @@ class TestTradingTasks:
         trade = TradeFactory(status=Trade.Status.COMPLETED)
         TradeShipmentFactory(trade=trade, sender=user_a, receiver=user_b)
         TradeShipmentFactory(trade=trade, sender=user_b, receiver=user_a)
-        
-        # User A has rated, B has not
+
         RatingFactory(trade=trade, rater=user_a, rated=user_b)
-        
+
         send_rating_reminders()
-        
-        # Only B should be reminded
+
         assert mock_async.called
-        # First arg is the task name, second is trade_id, third is user_id
         reminded_user_id = mock_async.call_args[0][2]
         assert str(reminded_user_id) == str(user_b.id)
-        
+
         trade.refresh_from_db()
         assert trade.rating_reminders_sent == 1
 
-    def test_auto_close_trades_unshipped(self):
-        trade = TradeFactory(status=Trade.Status.CONFIRMED)
+
+@pytest.mark.django_db
+class TestAutoCloseTrades:
+    def test_confirmed_trade_restores_books(self):
+        """CONFIRMED trade: books restored, no ratings, no total_trades change."""
+        sender = UserFactory(total_trades=0)
+        receiver = UserFactory(total_trades=0)
+        trade = make_expired_trade(status=Trade.Status.CONFIRMED)
         ub = UserBookFactory(status=UserBook.Status.RESERVED)
-        TradeShipmentFactory(trade=trade, user_book=ub, status=TradeShipment.Status.PENDING)
-        
-        # Make it old
-        Trade.objects.filter(pk=trade.pk).update(auto_close_at=timezone.now() - timedelta(days=1))
-        
+        TradeShipmentFactory(trade=trade, sender=sender, receiver=receiver, user_book=ub, status=TradeShipment.Status.PENDING)
+
         auto_close_trades()
-        
+
         trade.refresh_from_db()
         assert trade.status == Trade.Status.AUTO_CLOSED
         ub.refresh_from_db()
         assert ub.status == UserBook.Status.AVAILABLE
+        sender.refresh_from_db()
+        assert sender.total_trades == 0
+        assert Rating.objects.filter(trade=trade).count() == 0
 
-    def test_auto_close_trades_shipped(self):
-        user = UserFactory(total_trades=0)
-        trade = TradeFactory(status=Trade.Status.SHIPPING)
+    def test_shipping_valid_tracking_credits_both_parties(self):
+        """SHIPPING trade with valid tracking: 5-star rating, both parties credited."""
+        sender = UserFactory(total_trades=0)
+        receiver = UserFactory(total_trades=0)
+        trade = make_expired_trade(status=Trade.Status.SHIPPING)
         ub = UserBookFactory(status=UserBook.Status.RESERVED)
-        s = TradeShipmentFactory(trade=trade, sender=user, user_book=ub, status=TradeShipment.Status.SHIPPED)
-        
-        Trade.objects.filter(pk=trade.pk).update(auto_close_at=timezone.now() - timedelta(days=1))
-        
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver, user_book=ub,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="1Z999AA10123456784",
+        )
+
         auto_close_trades()
-        
+
         trade.refresh_from_db()
         assert trade.status == Trade.Status.AUTO_CLOSED
         ub.refresh_from_db()
         assert ub.status == UserBook.Status.TRADED
-        user.refresh_from_db()
-        assert user.total_trades == 1
+        sender.refresh_from_db()
+        receiver.refresh_from_db()
+        assert sender.total_trades == 1
+        assert receiver.total_trades == 1
+        rating = Rating.objects.get(trade=trade)
+        assert rating.score == 5
+        assert rating.rated == sender
+
+    def test_shipping_no_tracking_penalizes_sender(self):
+        """SHIPPING trade with no tracking: 1-star rating, book restored, no credit."""
+        sender = UserFactory(total_trades=0)
+        receiver = UserFactory(total_trades=0)
+        trade = make_expired_trade(status=Trade.Status.SHIPPING)
+        ub = UserBookFactory(status=UserBook.Status.RESERVED)
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver, user_book=ub,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="",
+        )
+
+        auto_close_trades()
+
+        trade.refresh_from_db()
+        assert trade.status == Trade.Status.AUTO_CLOSED
+        ub.refresh_from_db()
+        assert ub.status == UserBook.Status.AVAILABLE
+        sender.refresh_from_db()
+        receiver.refresh_from_db()
+        assert sender.total_trades == 0
+        assert receiver.total_trades == 0
+        rating = Rating.objects.get(trade=trade)
+        assert rating.score == 1
+        assert rating.comment == "Did not ship"
+        assert rating.rated == sender
+
+    def test_already_received_shipment_gets_credit(self):
+        """Shipment already RECEIVED before auto-close still gets 5-star credit."""
+        sender = UserFactory(total_trades=0)
+        receiver = UserFactory(total_trades=0)
+        trade = make_expired_trade(status=Trade.Status.ONE_RECEIVED)
+        ub = UserBookFactory(status=UserBook.Status.RESERVED)
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver, user_book=ub,
+            status=TradeShipment.Status.RECEIVED,
+            tracking_number="",
+        )
+
+        auto_close_trades()
+
+        rating = Rating.objects.get(trade=trade)
+        assert rating.score == 5
+
+    def test_mixed_shipments_independent_outcomes(self):
+        """One shipment succeeds, one fails — outcomes are independent."""
+        sender_a = UserFactory(total_trades=0)
+        sender_b = UserFactory(total_trades=0)
+        receiver_a = UserFactory(total_trades=0)
+        receiver_b = UserFactory(total_trades=0)
+        trade = make_expired_trade(status=Trade.Status.SHIPPING)
+
+        ub_a = UserBookFactory(status=UserBook.Status.RESERVED)
+        ub_b = UserBookFactory(status=UserBook.Status.RESERVED)
+
+        TradeShipmentFactory(
+            trade=trade, sender=sender_a, receiver=receiver_a, user_book=ub_a,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="1Z999AA10123456784",
+        )
+        TradeShipmentFactory(
+            trade=trade, sender=sender_b, receiver=receiver_b, user_book=ub_b,
+            status=TradeShipment.Status.PENDING,
+            tracking_number="",
+        )
+
+        auto_close_trades()
+
+        ub_a.refresh_from_db()
+        ub_b.refresh_from_db()
+        assert ub_a.status == UserBook.Status.TRADED
+        assert ub_b.status == UserBook.Status.AVAILABLE
+
+        sender_a.refresh_from_db()
+        sender_b.refresh_from_db()
+        assert sender_a.total_trades == 1
+        assert sender_b.total_trades == 0
+
+        ratings = Rating.objects.filter(trade=trade).order_by("score")
+        assert ratings[0].score == 1
+        assert ratings[1].score == 5
+
+    def test_idempotent_second_call_is_noop(self):
+        """Calling auto_close_trades twice on the same trade does not double-process it."""
+        sender = UserFactory(total_trades=0)
+        receiver = UserFactory(total_trades=0)
+        trade = make_expired_trade(status=Trade.Status.SHIPPING)
+        ub = UserBookFactory(status=UserBook.Status.RESERVED)
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver, user_book=ub,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="1Z999AA10123456784",
+        )
+
+        auto_close_trades()
+        auto_close_trades()  # second call
+
+        sender.refresh_from_db()
+        assert sender.total_trades == 1  # not 2
+        assert Rating.objects.filter(trade=trade).count() == 1  # not 2
+
+
+@pytest.mark.django_db
+class TestSendTradeClosureWarnings:
+    @patch("django_q.tasks.async_task")
+    def test_warns_shipping_trade_within_window(self, mock_async):
+        """A SHIPPING trade within 2 days with no valid tracking gets a warning."""
+        sender = UserFactory()
+        receiver = UserFactory()
+        trade = TradeFactory(status=Trade.Status.SHIPPING)
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() + timedelta(days=1)
+        )
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="",
+        )
+
+        send_trade_closure_warnings()
+
+        assert mock_async.called
+        trade.refresh_from_db()
+        assert trade.closure_warning_sent_at is not None
+
+    @patch("django_q.tasks.async_task")
+    def test_does_not_rewarn_same_trade(self, mock_async):
+        """A trade that already received a warning is not warned again."""
+        sender = UserFactory()
+        receiver = UserFactory()
+        trade = TradeFactory(status=Trade.Status.SHIPPING)
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() + timedelta(days=1),
+            closure_warning_sent_at=timezone.now() - timedelta(hours=1),
+        )
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="",
+        )
+
+        send_trade_closure_warnings()
+
+        assert not mock_async.called
+
+    @patch("django_q.tasks.async_task")
+    def test_does_not_warn_outside_window(self, mock_async):
+        """A trade more than 2 days away is not warned."""
+        sender = UserFactory()
+        receiver = UserFactory()
+        trade = TradeFactory(status=Trade.Status.SHIPPING)
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() + timedelta(days=5)
+        )
+        TradeShipmentFactory(trade=trade, sender=sender, receiver=receiver, tracking_number="")
+
+        send_trade_closure_warnings()
+
+        assert not mock_async.called
+
+    @patch("django_q.tasks.async_task")
+    def test_does_not_warn_when_valid_tracking_present(self, mock_async):
+        """A shipment with valid tracking does not trigger a warning."""
+        sender = UserFactory()
+        receiver = UserFactory()
+        trade = TradeFactory(status=Trade.Status.SHIPPING)
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() + timedelta(days=1)
+        )
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="1Z999AA10123456784",
+        )
+
+        send_trade_closure_warnings()
+
+        assert not mock_async.called
+
+    @patch("django_q.tasks.async_task")
+    def test_confirmed_trade_warns_all_parties(self, mock_async):
+        """A CONFIRMED trade within window warns all senders with 'not_started' reason."""
+        sender_a = UserFactory()
+        receiver_a = UserFactory()
+        trade = TradeFactory(status=Trade.Status.CONFIRMED)
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() + timedelta(days=1)
+        )
+        TradeShipmentFactory(trade=trade, sender=sender_a, receiver=receiver_a)
+
+        send_trade_closure_warnings()
+
+        assert mock_async.called
+        call_args = mock_async.call_args[0]
+        assert call_args[3] == "not_started"
+
+
+@pytest.mark.django_db
+class TestTradeRateViewAutoClosedGuard:
+    def test_rating_after_auto_close_does_not_flip_to_completed(self, client):
+        """A human rating on an AUTO_CLOSED trade does not change status to COMPLETED."""
+        from rest_framework.test import APIClient
+        from apps.tests.factories import TradeFactory, TradeShipmentFactory, UserFactory, UserBookFactory
+
+        user_a = UserFactory()
+        user_b = UserFactory()
+        trade = TradeFactory(status=Trade.Status.AUTO_CLOSED)
+        ub_a = UserBookFactory(user=user_a)
+        ub_b = UserBookFactory(user=user_b)
+        TradeShipmentFactory(trade=trade, sender=user_a, receiver=user_b, user_book=ub_a)
+        TradeShipmentFactory(trade=trade, sender=user_b, receiver=user_a, user_book=ub_b)
+
+        api = APIClient()
+        api.force_authenticate(user=user_a)
+        api.post(
+            f"/api/v1/trades/{trade.pk}/rate/",
+            {"rated_user_id": str(user_b.pk), "score": 5, "book_condition_accurate": True},
+            format="json",
+        )
+
+        trade.refresh_from_db()
+        assert trade.status == Trade.Status.AUTO_CLOSED

--- a/apps/trading/tests/test_trading_tasks.py
+++ b/apps/trading/tests/test_trading_tasks.py
@@ -285,6 +285,124 @@ class TestSendTradeClosureWarnings:
 
 
 @pytest.mark.django_db
+class TestAutoCloseDeletedUser:
+    def test_auto_close_handles_deleted_user_gracefully(self):
+        """If a sender is deleted (cascade-deleting their shipments) before auto-close
+        runs, the task should not crash — the trade closes with no shipments processed."""
+        sender = UserFactory(total_trades=0)
+        receiver = UserFactory(total_trades=0)
+        trade = make_expired_trade(status=Trade.Status.SHIPPING)
+        ub = UserBookFactory(user=sender, status=UserBook.Status.RESERVED)
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver, user_book=ub,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="1Z999AA10123456784",
+        )
+
+        # Delete the sender — cascades to their shipment
+        sender.delete()
+
+        # Task must not raise
+        auto_close_trades()
+
+        trade.refresh_from_db()
+        assert trade.status == Trade.Status.AUTO_CLOSED
+        # No ratings created since there were no shipments to evaluate
+        assert Rating.objects.filter(trade=trade).count() == 0
+
+
+@pytest.mark.django_db
+class TestClosureWarningBoundary:
+    @patch("django_q.tasks.async_task")
+    def test_trade_exactly_at_boundary_is_warned(self, mock_async):
+        """A trade whose auto_close_at equals exactly now+2d is inside the window."""
+        sender = UserFactory()
+        receiver = UserFactory()
+        trade = TradeFactory(status=Trade.Status.SHIPPING)
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() + timedelta(days=2)
+        )
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="",
+        )
+
+        send_trade_closure_warnings()
+
+        assert mock_async.called
+
+    @patch("django_q.tasks.async_task")
+    def test_trade_just_outside_boundary_not_warned(self, mock_async):
+        """A trade 2 days + 2 hours away is outside the window."""
+        sender = UserFactory()
+        receiver = UserFactory()
+        trade = TradeFactory(status=Trade.Status.SHIPPING)
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() + timedelta(days=2, hours=2)
+        )
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="",
+        )
+
+        send_trade_closure_warnings()
+
+        assert not mock_async.called
+
+    @patch("django_q.tasks.async_task")
+    def test_late_cron_still_warns_trade_past_lower_bound(self, mock_async):
+        """If cron runs late, a trade whose auto_close_at has already passed (but hasn't
+        been auto-closed yet) should still receive a warning rather than silently missing
+        it. The lower bound of the window is now, so such a trade is excluded. This test
+        documents the known limitation: trades that slip into the past before the daily
+        warning task runs will not receive a warning email."""
+        sender = UserFactory()
+        receiver = UserFactory()
+        trade = TradeFactory(status=Trade.Status.SHIPPING)
+        # auto_close_at is 3 hours in the past — cron missed its window
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() - timedelta(hours=3)
+        )
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="",
+        )
+
+        send_trade_closure_warnings()
+
+        # Known limitation: warning is NOT sent because the trade is past the lower bound.
+        # The auto_close task will handle it on its next weekly run instead.
+        assert not mock_async.called
+
+    @patch("django_q.tasks.async_task")
+    def test_idempotent_second_warning_call_is_noop(self, mock_async):
+        """A second run of send_trade_closure_warnings does not re-warn the same trade."""
+        sender = UserFactory()
+        receiver = UserFactory()
+        trade = TradeFactory(status=Trade.Status.SHIPPING)
+        Trade.objects.filter(pk=trade.pk).update(
+            auto_close_at=timezone.now() + timedelta(days=1)
+        )
+        TradeShipmentFactory(
+            trade=trade, sender=sender, receiver=receiver,
+            status=TradeShipment.Status.SHIPPED,
+            tracking_number="",
+        )
+
+        send_trade_closure_warnings()
+        first_call_count = mock_async.call_count
+
+        send_trade_closure_warnings()
+        second_call_count = mock_async.call_count
+
+        assert first_call_count == 1
+        assert second_call_count == 1  # no additional calls on second run
+
+
+@pytest.mark.django_db
 class TestTradeRateViewAutoClosedGuard:
     def test_rating_after_auto_close_does_not_flip_to_completed(self, client):
         """A human rating on an AUTO_CLOSED trade does not change status to COMPLETED."""

--- a/apps/trading/tests/test_utils.py
+++ b/apps/trading/tests/test_utils.py
@@ -1,0 +1,35 @@
+import pytest
+from apps.trading.utils import is_valid_tracking_number
+
+
+class TestIsValidTrackingNumber:
+    def test_empty_string(self):
+        assert is_valid_tracking_number("") is False
+
+    def test_none_like_empty(self):
+        assert is_valid_tracking_number("   ") is False
+
+    def test_phone_number_rejected(self):
+        assert is_valid_tracking_number("5551234567") is False
+
+    def test_short_digits_rejected(self):
+        assert is_valid_tracking_number("12345") is False
+
+    def test_usps_valid(self):
+        # 9 prefix + 22 digits total
+        assert is_valid_tracking_number("9400100000000000000000") is True
+
+    def test_ups_valid(self):
+        assert is_valid_tracking_number("1Z999AA10123456784") is True
+
+    def test_ups_lowercase(self):
+        assert is_valid_tracking_number("1z999aa10123456784") is True
+
+    def test_fedex_15_digit(self):
+        assert is_valid_tracking_number("123456789012345") is True
+
+    def test_fedex_prefix_96(self):
+        assert is_valid_tracking_number("96" + "1" * 16) is True
+
+    def test_garbage_string_rejected(self):
+        assert is_valid_tracking_number("HELLO-WORLD") is False

--- a/apps/trading/tests/test_utils.py
+++ b/apps/trading/tests/test_utils.py
@@ -33,3 +33,16 @@ class TestIsValidTrackingNumber:
 
     def test_garbage_string_rejected(self):
         assert is_valid_tracking_number("HELLO-WORLD") is False
+
+    def test_usps_with_internal_spaces(self):
+        # Copy-pasted with spaces between digit groups
+        assert is_valid_tracking_number("9400 1000 0000 0000 0000 00") is True
+
+    def test_ups_with_spaces(self):
+        assert is_valid_tracking_number("1Z999 AA1 0123 456784") is True
+
+    def test_trailing_whitespace(self):
+        assert is_valid_tracking_number("1Z999AA10123456784   ") is True
+
+    def test_leading_whitespace(self):
+        assert is_valid_tracking_number("   1Z999AA10123456784") is True

--- a/apps/trading/utils.py
+++ b/apps/trading/utils.py
@@ -1,0 +1,16 @@
+import re
+
+# Heuristic patterns — not exhaustive, cover the most common US carrier formats.
+_TRACKING_PATTERNS = [
+    re.compile(r'^(9[0-5])\d{20}$'),        # USPS
+    re.compile(r'^1Z[0-9A-Z]{16}$'),          # UPS
+    re.compile(r'^(?:96|98)\d{16}$'),         # FedEx (carrier-specific prefixes)
+    re.compile(r'^[0-9]{15}$'),               # FedEx 15-digit express
+]
+
+
+def is_valid_tracking_number(value: str) -> bool:
+    if not value:
+        return False
+    normalized = value.strip().upper()
+    return any(p.match(normalized) for p in _TRACKING_PATTERNS)

--- a/apps/trading/utils.py
+++ b/apps/trading/utils.py
@@ -12,5 +12,7 @@ _TRACKING_PATTERNS = [
 def is_valid_tracking_number(value: str) -> bool:
     if not value:
         return False
-    normalized = value.strip().upper()
+    # Strip all whitespace (leading, trailing, internal) before matching.
+    # Users frequently copy tracking numbers with spaces between digit groups.
+    normalized = re.sub(r'\s+', '', value).upper()
     return any(p.match(normalized) for p in _TRACKING_PATTERNS)

--- a/apps/trading/views.py
+++ b/apps/trading/views.py
@@ -448,7 +448,10 @@ class TradeRateView(APIView):
                     "rater_id", flat=True
                 )
             )
-            if rated_ids >= all_rater_ids and trade.status != Trade.Status.COMPLETED:
+            if rated_ids >= all_rater_ids and trade.status not in [
+                Trade.Status.COMPLETED,
+                Trade.Status.AUTO_CLOSED,
+            ]:
                 trade.status = Trade.Status.COMPLETED
                 trade.completed_at = timezone.now()
                 trade.save(update_fields=["status", "completed_at"])

--- a/docs/bookswap-architecture.md
+++ b/docs/bookswap-architecture.md
@@ -244,7 +244,8 @@ Trade
 ├── updated_at          timestamp
 ├── completed_at        nullable timestamp
 ├── auto_close_at       nullable timestamp (set to confirmed_at + 3 weeks)
-└── rating_reminders_sent  integer, default 0 (0, 1, 2, or 3 weekly reminders)
+├── rating_reminders_sent  integer, default 0 (0, 1, 2, or 3 weekly reminders)
+└── closure_warning_sent_at  nullable timestamp (set when 2-day warning is dispatched)
 
 TradeShipment (one per direction in the trade)
 ├── id                  UUID, primary key
@@ -265,7 +266,7 @@ TradeShipment (one per direction in the trade)
 - Address is revealed to both parties at this point.
 - Each shipment is tracked independently — one side might ship before the other.
 - `one_received` means one party confirmed receipt; `completed` means both have.
-- **Auto-close logic:** After a match is accepted, a weekly background task sends rating reminders to users who haven't rated yet (up to 3 reminders). After 3 weeks with no rating, the trade is auto-closed with status `auto_closed` — the book is assumed received, UserBooks move to `traded`, and user trade counts are updated. No rating is recorded.
+- **Auto-close logic:** After a match is accepted, a weekly background task sends rating reminders to users who haven't rated yet (up to 3 reminders). After 3 weeks, the trade is auto-closed with status `auto_closed`. Per-shipment: valid tracking or received → 5-star auto-rating from 'trademanager'; no valid tracking → 1-star 'Did not ship' auto-rating, book restored.
 - **No dispute resolution.** The rating system is the only accountability mechanism. Users who send wrong books or don't ship will accumulate bad ratings.
 
 ### Ratings
@@ -283,7 +284,7 @@ Rating
 ├── created_at          timestamp
 └── updated_at          timestamp
 
-UNIQUE CONSTRAINT: (trade_id, rater_id) — one rating per user per trade
+UNIQUE CONSTRAINT: (trade_id, rater_id, rated_id) — one rating per rater+rated pair per trade
 ```
 
 **Notes:**
@@ -482,10 +483,19 @@ After a trade is confirmed:
             → Increment rating_reminders_sent
         → If auto_close_at has passed AND trade is not completed:
             → Set status = 'auto_closed'
-            → Mark all shipments as 'received' (assumed)
-            → Mark UserBooks as 'traded'
-            → Increment User.total_trades for both parties
-            → No rating is recorded
+            → If trade was CONFIRMED (nothing shipped):
+                → Restore all UserBooks to 'available'
+                → No ratings, no trade credit
+            → If trade was SHIPPING or ONE_RECEIVED (per shipment):
+                → Shipment has valid tracking OR status=RECEIVED:
+                    → Mark shipment RECEIVED, UserBook TRADED
+                    → Increment total_trades for sender AND receiver
+                    → Create 5-star Rating from 'trademanager' system user
+                → Shipment has no valid tracking:
+                    → Mark shipment NOT_RECEIVED, UserBook AVAILABLE
+                    → No trade credit increment
+                    → Create 1-star Rating ("Did not ship") from 'trademanager'
+            → Daily task (send_trade_closure_warnings) warns affected users 2 days before
 
 When a user DOES submit a rating:
     → Score (1-5) + optional comment + condition accuracy

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@marsidev/react-turnstile": "^1.5.1",
         "@radix-ui/react-accordion": "^1.2.2",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.15",
         "@tanstack/react-query": "^5.59.20",
         "axios": "^1.7.7",
@@ -2431,6 +2432,34 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
@@ -2536,6 +2565,42 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+      "integrity": "sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,13 +17,14 @@
     "e2e:debug": "PWDEBUG=1 playwright test --project=critical"
   },
   "dependencies": {
+    "@marsidev/react-turnstile": "^1.5.1",
     "@radix-ui/react-accordion": "^1.2.2",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
     "@tanstack/react-query": "^5.59.20",
     "axios": "^1.7.7",
     "barcode-detector": "^3.1.2",
     "date-fns": "^4.1.0",
-    "@marsidev/react-turnstile": "^1.5.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.53.2",

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -16,7 +16,12 @@ const FAQ_DATA = [
   {
     id: 'shipping',
     question: 'How does shipping work?',
-    answer: 'Once a trade is confirmed, you will receive the shipping address of your trade partner. You are responsible for shipping your book to them, and in return, someone will ship a book to you. We recommend using USPS Media Mail for cost-effective shipping within the US. You can also use UPS or Fedex and enter those tracking numbers.'
+    answer: 'Once a trade is confirmed, you will receive the shipping address of your trade partner. You are responsible for shipping your book to them, and in return, someone will ship a book to you. We recommend using USPS Media Mail for cost-effective shipping within the US. You can also use UPS or FedEx and enter those tracking numbers. A valid tracking number is required to earn trade credit.'
+  },
+  {
+    id: 'auto-close',
+    question: 'What happens if a trade is never completed?',
+    answer: 'Trades automatically close after 3 weeks. If you shipped your book with a valid USPS, UPS, or FedEx tracking number — or your trade partner marked it as received — you will earn trade credit and an automatic 5-star review from "Trade Manager". If no valid tracking number is on file when the trade closes, your book will be returned to your available list and you will receive a 1-star "Did not ship" review. You will receive a warning email 2 days before auto-close if your tracking information is missing.'
   },
   {
     id: 'is-it-free',

--- a/frontend/src/pages/About.test.jsx
+++ b/frontend/src/pages/About.test.jsx
@@ -46,6 +46,11 @@ describe('About Page', () => {
     expect(screen.getByText('How does shipping work?')).toBeInTheDocument();
   });
 
+  it('renders the auto-close FAQ entry', () => {
+    render(<About />);
+    expect(screen.getByText('What happens if a trade is never completed?')).toBeInTheDocument();
+  });
+
   it('toggles FAQ items when clicked', async () => {
     render(<About />);
 

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -10,7 +10,21 @@ import { format } from 'date-fns';
 import { getBookCoverUrl, getBookPrimaryAuthor } from '../utils/book.js';
 import { buildTradeRatingPayload, mapTradeForView } from '../adapters/trades.js';
 import Tooltip from '../components/common/Tooltip.jsx';
+import * as AlertDialog from '@radix-ui/react-alert-dialog';
 import styles from './TradeDetail.module.css';
+
+const TRACKING_PATTERNS = [
+  /^(9[0-5])\d{20}$/,
+  /^1Z[0-9A-Z]{16}$/i,
+  /^(?:96|98)\d{16}$/,
+  /^\d{15}$/,
+];
+
+function isValidTrackingNumber(value) {
+  if (!value) return false;
+  const normalized = value.trim().toUpperCase();
+  return TRACKING_PATTERNS.some((p) => p.test(normalized));
+}
 
 const MESSAGE_MAX_LENGTH = 1000;
 
@@ -130,6 +144,8 @@ export default function TradeDetail() {
   const [msgContent, setMsgContent] = useState('');
   const [trackingNumber, setTrackingNumber] = useState('');
   const [showShipForm, setShowShipForm] = useState(false);
+  const [showTrackingWarning, setShowTrackingWarning] = useState(false);
+  const [pendingShipSubmit, setPendingShipSubmit] = useState(false);
   const [showRateForm, setShowRateForm] = useState(false);
   const [ratingScore, setRatingScore] = useState(5);
   const [ratingComment, setRatingComment] = useState('');
@@ -233,10 +249,19 @@ export default function TradeDetail() {
 
   const messages = messagesData?.results ?? messagesData ?? [];
 
-  const isCompleted = tradeView.status === 'completed';
+  const isCompleted = ['completed', 'auto_closed'].includes(tradeView.status);
   const canMarkShipped = ['confirmed', 'shipping', 'one_received'].includes(tradeView.status) && !tradeView.myShipped;
   const canMarkReceived = ['shipping', 'one_received'].includes(tradeView.status) && tradeView.theyShipped && !tradeView.iReceived;
   const canRate = isCompleted && !tradeView.iRated;
+
+  const daysUntilClose = trade.auto_close_at
+    ? Math.ceil((new Date(trade.auto_close_at) - new Date()) / (1000 * 60 * 60 * 24))
+    : null;
+  const showTrackingWarningBanner =
+    canMarkShipped &&
+    daysUntilClose !== null &&
+    daysUntilClose <= 7 &&
+    !isValidTrackingNumber(tradeView.myTracking);
   const messageLength = msgContent.length;
 
   function submitMessageIfValid() {
@@ -273,6 +298,11 @@ export default function TradeDetail() {
               {trade.created_at && (
                 <p className={styles.tradeDate}>
                   Started {format(new Date(trade.created_at), 'MMMM d, yyyy')}
+                </p>
+              )}
+              {trade.auto_close_at && !['completed', 'auto_closed'].includes(tradeView.status) && (
+                <p className={styles.autoCloseDate}>
+                  Auto-closes {format(new Date(trade.auto_close_at), 'MMMM d, yyyy')}
                 </p>
               )}
             </div>
@@ -329,6 +359,14 @@ export default function TradeDetail() {
             <div className="alert alert-error">{actionError}</div>
           )}
 
+          {showTrackingWarningBanner && (
+            <div className="alert alert-error" data-testid="tracking-warning-banner">
+              No valid tracking number on file. If not provided before{' '}
+              {format(new Date(trade.auto_close_at), 'MMMM d, yyyy')}, this trade will
+              auto-close with a 1-star review.
+            </div>
+          )}
+
           <div className={styles.actions}>
             {canMarkShipped && (
               <>
@@ -351,7 +389,13 @@ export default function TradeDetail() {
                     <div style={{ display: 'flex', gap: '0.5rem', marginTop: '0.75rem' }}>
                       <button
                         className="btn btn-success"
-                        onClick={() => markShippedMutation.mutate()}
+                        onClick={() => {
+                          if (trackingNumber && !isValidTrackingNumber(trackingNumber)) {
+                            setShowTrackingWarning(true);
+                          } else {
+                            markShippedMutation.mutate();
+                          }
+                        }}
                         disabled={markShippedMutation.isPending}
                       >
                         {markShippedMutation.isPending ? 'Marking...' : 'Confirm Shipped'}
@@ -460,6 +504,36 @@ export default function TradeDetail() {
             )}
           </div>
         </div>
+
+        <AlertDialog.Root open={showTrackingWarning} onOpenChange={setShowTrackingWarning}>
+          <AlertDialog.Portal>
+            <AlertDialog.Overlay className={styles.dialogOverlay} />
+            <AlertDialog.Content className={styles.dialogContent}>
+              <AlertDialog.Title className={styles.dialogTitle}>
+                Unrecognized tracking number
+              </AlertDialog.Title>
+              <AlertDialog.Description className={styles.dialogDescription}>
+                This tracking number doesn&apos;t match a known USPS, UPS, or FedEx format. Are you sure it&apos;s correct?
+              </AlertDialog.Description>
+              <div className={styles.dialogActions}>
+                <AlertDialog.Cancel asChild>
+                  <button className="btn btn-outline-danger">Go Back</button>
+                </AlertDialog.Cancel>
+                <AlertDialog.Action asChild>
+                  <button
+                    className="btn btn-primary"
+                    onClick={() => {
+                      setShowTrackingWarning(false);
+                      markShippedMutation.mutate();
+                    }}
+                  >
+                    Continue Anyway
+                  </button>
+                </AlertDialog.Action>
+              </div>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>
 
         {/* Right: Messages */}
         <div className={styles.sidebar}>

--- a/frontend/src/pages/TradeDetail.jsx
+++ b/frontend/src/pages/TradeDetail.jsx
@@ -22,7 +22,7 @@ const TRACKING_PATTERNS = [
 
 function isValidTrackingNumber(value) {
   if (!value) return false;
-  const normalized = value.trim().toUpperCase();
+  const normalized = value.replace(/\s+/g, '').toUpperCase();
   return TRACKING_PATTERNS.some((p) => p.test(normalized));
 }
 

--- a/frontend/src/pages/TradeDetail.module.css
+++ b/frontend/src/pages/TradeDetail.module.css
@@ -320,3 +320,47 @@
   color: var(--color-gray-500);
   text-align: right;
 }
+
+.dialogOverlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(0, 0, 0, 0.45);
+  z-index: 100;
+}
+
+.dialogContent {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--color-white);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  width: min(90vw, 28rem);
+  z-index: 101;
+  box-shadow: var(--shadow-lg);
+}
+
+.dialogTitle {
+  font-size: 1.125rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.dialogDescription {
+  font-size: 0.9375rem;
+  color: var(--color-gray-700);
+  margin-bottom: 1.25rem;
+}
+
+.dialogActions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.autoCloseDate {
+  font-size: 0.8125rem;
+  color: var(--color-gray-500);
+  margin-top: 0.125rem;
+}

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -1350,7 +1350,9 @@ describe('TradeDetail page', () => {
         await waitFor(() => expect(trades.markShipped).toHaveBeenCalled());
     });
 
-    it('submits when user clicks Continue Anyway in AlertDialog', async () => {
+    it('submits when user clicks Continue Anyway in AlertDialog and call succeeds', async () => {
+        // Verifies the backend override path: unrecognized format → dialog → Continue Anyway
+        // → markShipped is called and resolves (no 400 rejection from soft validation).
         trades.getDetail.mockResolvedValue({ data: makeTrade({ status: 'confirmed' }) });
         trades.getMessages.mockResolvedValue({ data: [] });
         trades.markShipped.mockResolvedValue({ data: {} });
@@ -1362,6 +1364,26 @@ describe('TradeDetail page', () => {
         await screen.findByText(/unrecognized tracking number/i);
         await userEvent.click(screen.getByRole('button', { name: /continue anyway/i }));
 
+        await waitFor(() => expect(trades.markShipped).toHaveBeenCalledWith(
+            'trade-1',
+            { tracking_number: 'CUSTOMCARRIER99' },
+        ));
+        // markShipped resolved without error — no actionError rendered
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('does not show AlertDialog for tracking number with internal spaces that normalizes to valid', async () => {
+        trades.getDetail.mockResolvedValue({ data: makeTrade({ status: 'confirmed' }) });
+        trades.getMessages.mockResolvedValue({ data: [] });
+        trades.markShipped.mockResolvedValue({ data: {} });
+        renderWithProviders(<TradeDetail />);
+
+        await userEvent.click(await screen.findByRole('button', { name: /mark my book as shipped/i }));
+        // UPS number with spaces — should normalize and pass validation
+        await userEvent.type(screen.getByRole('textbox', { name: /tracking number/i }), '1Z999 AA1 0123 456784');
+        await userEvent.click(screen.getByRole('button', { name: /confirm shipped/i }));
+
+        expect(screen.queryByText(/unrecognized tracking number/i)).not.toBeInTheDocument();
         await waitFor(() => expect(trades.markShipped).toHaveBeenCalled());
     });
 

--- a/frontend/src/pages/TradeDetail.test.jsx
+++ b/frontend/src/pages/TradeDetail.test.jsx
@@ -130,9 +130,9 @@ describe('TradeDetail page', () => {
         trades.markShipped.mockResolvedValue({ data: {} });
         renderWithProviders(<TradeDetail />);
         await userEvent.click(await screen.findByRole('button', { name: /mark my book as shipped/i }));
-        await userEvent.type(screen.getByRole('textbox', { name: /tracking number/i }), 'TRACK123');
+        await userEvent.type(screen.getByRole('textbox', { name: /tracking number/i }), '1Z999AA10123456784');
         await userEvent.click(screen.getByRole('button', { name: /confirm shipped/i }));
-        await waitFor(() => expect(trades.markShipped).toHaveBeenCalledWith('trade-1', { tracking_number: 'TRACK123' }));
+        await waitFor(() => expect(trades.markShipped).toHaveBeenCalledWith('trade-1', { tracking_number: '1Z999AA10123456784' }));
     });
 
     it('shows "Mark Book Received" button when partner has shipped', async () => {
@@ -1319,5 +1319,112 @@ describe('TradeDetail page', () => {
         expect(msgTypeSelect).toHaveValue('issue_report');
         // issue_report tooltip content should be rendered in the DOM
         expect(screen.getByText(/damaged book|no contact/i)).toBeInTheDocument();
+    });
+
+    it('shows AlertDialog when invalid tracking number is submitted', async () => {
+        trades.getDetail.mockResolvedValue({ data: makeTrade({ status: 'confirmed' }) });
+        trades.getMessages.mockResolvedValue({ data: [] });
+        renderWithProviders(<TradeDetail />);
+
+        await userEvent.click(await screen.findByRole('button', { name: /mark my book as shipped/i }));
+        const trackingInput = screen.getByRole('textbox', { name: /tracking number/i });
+        await userEvent.type(trackingInput, 'BADTRACKING123');
+        await userEvent.click(screen.getByRole('button', { name: /confirm shipped/i }));
+
+        expect(await screen.findByText(/unrecognized tracking number/i)).toBeInTheDocument();
+        expect(trades.markShipped).not.toHaveBeenCalled();
+    });
+
+    it('does not show AlertDialog for valid UPS tracking number', async () => {
+        trades.getDetail.mockResolvedValue({ data: makeTrade({ status: 'confirmed' }) });
+        trades.getMessages.mockResolvedValue({ data: [] });
+        trades.markShipped.mockResolvedValue({ data: {} });
+        renderWithProviders(<TradeDetail />);
+
+        await userEvent.click(await screen.findByRole('button', { name: /mark my book as shipped/i }));
+        const trackingInput = screen.getByRole('textbox', { name: /tracking number/i });
+        await userEvent.type(trackingInput, '1Z999AA10123456784');
+        await userEvent.click(screen.getByRole('button', { name: /confirm shipped/i }));
+
+        expect(screen.queryByText(/unrecognized tracking number/i)).not.toBeInTheDocument();
+        await waitFor(() => expect(trades.markShipped).toHaveBeenCalled());
+    });
+
+    it('submits when user clicks Continue Anyway in AlertDialog', async () => {
+        trades.getDetail.mockResolvedValue({ data: makeTrade({ status: 'confirmed' }) });
+        trades.getMessages.mockResolvedValue({ data: [] });
+        trades.markShipped.mockResolvedValue({ data: {} });
+        renderWithProviders(<TradeDetail />);
+
+        await userEvent.click(await screen.findByRole('button', { name: /mark my book as shipped/i }));
+        await userEvent.type(screen.getByRole('textbox', { name: /tracking number/i }), 'CUSTOMCARRIER99');
+        await userEvent.click(screen.getByRole('button', { name: /confirm shipped/i }));
+        await screen.findByText(/unrecognized tracking number/i);
+        await userEvent.click(screen.getByRole('button', { name: /continue anyway/i }));
+
+        await waitFor(() => expect(trades.markShipped).toHaveBeenCalled());
+    });
+
+    it('shows tracking warning banner when auto_close_at is within 7 days and no valid tracking', async () => {
+        const soon = new Date();
+        soon.setDate(soon.getDate() + 3);
+        trades.getDetail.mockResolvedValue({
+            data: makeTrade({
+                status: 'shipping',
+                auto_close_at: soon.toISOString(),
+                shipments: [
+                    {
+                        sender: { id: 'user-1', username: 'me' },
+                        receiver: { id: 'user-2', username: 'partner' },
+                        status: 'pending',
+                        tracking_number: '',
+                        user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                    },
+                    {
+                        sender: { id: 'user-2', username: 'partner' },
+                        receiver: { id: 'user-1', username: 'me' },
+                        status: 'shipped',
+                        tracking_number: '',
+                        user_book: { condition: 'good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                    },
+                ],
+            }),
+        });
+        trades.getMessages.mockResolvedValue({ data: [] });
+        renderWithProviders(<TradeDetail />);
+
+        expect(await screen.findByTestId('tracking-warning-banner')).toBeInTheDocument();
+    });
+
+    it('does not show tracking warning banner when valid tracking is present', async () => {
+        const soon = new Date();
+        soon.setDate(soon.getDate() + 3);
+        trades.getDetail.mockResolvedValue({
+            data: makeTrade({
+                status: 'shipping',
+                auto_close_at: soon.toISOString(),
+                shipments: [
+                    {
+                        sender: { id: 'user-1', username: 'me' },
+                        receiver: { id: 'user-2', username: 'partner' },
+                        status: 'shipped',
+                        tracking_number: '1Z999AA10123456784',
+                        user_book: { condition: 'good', book: { id: 'b1', title: 'My Book', authors: [] } },
+                    },
+                    {
+                        sender: { id: 'user-2', username: 'partner' },
+                        receiver: { id: 'user-1', username: 'me' },
+                        status: 'shipped',
+                        tracking_number: '',
+                        user_book: { condition: 'good', book: { id: 'b2', title: 'Their Book', authors: [] } },
+                    },
+                ],
+            }),
+        });
+        trades.getMessages.mockResolvedValue({ data: [] });
+        renderWithProviders(<TradeDetail />);
+
+        await screen.findByText('My Book');
+        expect(screen.queryByTestId('tracking-warning-banner')).not.toBeInTheDocument();
     });
 });


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Per-shipment auto-close logic:** When a trade auto-closes after 3 weeks, each shipment is now evaluated individually. Senders with a valid tracking number (or whose shipment was already marked received) earn trade credit and an automatic 5-star review from the "Trade Manager" system account. Senders with no valid tracking receive a 1-star "Did not ship" review and have their book restored to available.
- **Pre-closure warning emails:** A new daily task (`send_trade_closure_warnings`) identifies trades within 2 days of auto-close and warns affected senders. Deduplication via `closure_warning_sent_at` prevents repeat warnings.
- **Backend tracking soft-validation:** `MarkShippedSerializer` now checks tracking numbers against known USPS/UPS/FedEx patterns and flags unrecognized formats (non-blocking — submission still succeeds).
- **Frontend improvements:** Radix `AlertDialog` replaces `window.confirm` for unrecognized tracking numbers; auto-close deadline is displayed on the trade detail page; a 7-day warning banner appears when no valid tracking is on file; FAQ updated with auto-close rules.

## Changes

### Models / migrations
- `Rating.unique_together` changed from `('trade', 'rater')` → `('trade', 'rater', 'rated')` so Trade Manager can rate multiple senders on the same trade without an `IntegrityError`
- `Trade.closure_warning_sent_at` field added for warning deduplication

### Backend
- `apps/trading/utils.py` — new `is_valid_tracking_number()` shared by tasks and serializer
- `apps/trading/tasks.py` — full rewrite of `auto_close_trades` (per-shipment logic, `select_for_update(skip_locked=True)` for concurrency safety, `recompute_rating_average` inside the transaction); new `send_trade_closure_warnings` task; Trade Manager helper with `is_active=False` guard
- `apps/trading/serializers.py` — soft tracking validation in `MarkShippedSerializer`
- `apps/trading/views.py` — `TradeRateView` no longer flips `AUTO_CLOSED` → `COMPLETED`
- `apps/notifications/tasks.py` — `send_closure_warning` stub
- `apps/notifications/management/commands/run_periodic_tasks.py` — `trade_closure_warnings` registered with daily crontab entry

### Frontend
- `TradeDetail.jsx` — Radix `AlertDialog` for unrecognized tracking, auto-close deadline display, 7-day in-page warning banner, `isCompleted` now includes `auto_closed` status
- `TradeDetail.module.css` — dialog and auto-close date styles
- `About.jsx` — shipping FAQ updated; new auto-close FAQ entry added
- `@radix-ui/react-alert-dialog` added as dependency

### Tests
- `apps/trading/tests/test_utils.py` — new: 10 unit tests for `is_valid_tracking_number`
- `apps/trading/tests/test_trading_tasks.py` — expanded: CONFIRMED restore, valid tracking credits both parties, no tracking penalizes sender, RECEIVED shipment gets credit, mixed outcomes, idempotency (second call is no-op), warning task deduplication, window boundary, CONFIRMED variant
- `apps/ratings/tests/test_ratings.py` — new: Trade Manager can rate two senders on same trade; cannot rate same sender twice
- `frontend/src/pages/TradeDetail.test.jsx` — new: AlertDialog on invalid tracking, no dialog on valid tracking, Continue Anyway submits, 7-day warning banner shown/hidden, About FAQ entry
- `frontend/src/pages/About.test.jsx` — new: auto-close FAQ entry present

## Test plan

- [ ] Run `pytest apps/trading/tests/ apps/ratings/tests/` against a live DB and confirm all pass
- [ ] Run `cd frontend && npm run test:run` — 599 tests pass
- [ ] Manually confirm a trade with no tracking auto-closes with 1-star rating and book restored
- [ ] Manually confirm a trade with valid UPS tracking auto-closes with 5-star rating and credit for both parties
- [ ] Confirm Trade Manager account is created with `is_active=False` and does not appear in any user-facing list
- [ ] Confirm `send_trade_closure_warnings` is registered in crontab and fires daily at 4am
- [ ] Confirm AlertDialog appears on unrecognized tracking input and does not appear on a valid USPS/UPS/FedEx input
- [ ] Confirm auto-close deadline is visible on the trade detail page

https://claude.ai/code/session_01SzXB5eCbn4RGzQkoJDhG7V
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzXB5eCbn4RGzQkoJDhG7V)_