### PR TITLE
Prevent rematch of declined pairings in direct and ring matches

### DIFF
--- a/apps/matching/admin.py
+++ b/apps/matching/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Match, MatchLeg
+from .models import DeclinedPairing, Match, MatchLeg
 
 
 class MatchLegInline(admin.TabularInline):
@@ -26,3 +26,10 @@ class MatchLegAdmin(admin.ModelAdmin):
     search_fields = ['sender__username', 'receiver__username']
     readonly_fields = ['id']
     raw_id_fields = ['match', 'sender', 'receiver', 'user_book']
+
+
+@admin.register(DeclinedPairing)
+class DeclinedPairingAdmin(admin.ModelAdmin):
+    list_display = ['id', 'user_book_a', 'user_book_b', 'declined_at']
+    readonly_fields = ['id', 'declined_at']
+    raw_id_fields = ['user_book_a', 'user_book_b']

--- a/apps/matching/migrations/0003_declinedpairing.py
+++ b/apps/matching/migrations/0003_declinedpairing.py
@@ -1,0 +1,63 @@
+import django.db.models.deletion
+import uuid
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("matching", "0002_remove_match_pending_status"),
+        ("inventory", "0002_wishlistitem_edition_preferences"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="DeclinedPairing",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                (
+                    "user_book_a",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="declined_pairings_as_a",
+                        to="inventory.userbook",
+                    ),
+                ),
+                (
+                    "user_book_b",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="declined_pairings_as_b",
+                        to="inventory.userbook",
+                    ),
+                ),
+                ("declined_at", models.DateTimeField(auto_now_add=True)),
+            ],
+            options={
+                "verbose_name": "Declined Pairing",
+                "verbose_name_plural": "Declined Pairings",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="declinedpairing",
+            constraint=models.UniqueConstraint(
+                fields=["user_book_a", "user_book_b"],
+                name="unique_declined_pairing",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="declinedpairing",
+            index=models.Index(
+                fields=["user_book_a", "user_book_b"],
+                name="matching_declinedpairing_books_idx",
+            ),
+        ),
+    ]

--- a/apps/matching/models.py
+++ b/apps/matching/models.py
@@ -78,3 +78,47 @@ class MatchLeg(models.Model):
             f'Leg {self.position}: {self.sender.username} → '
             f'{self.receiver.username} ({self.user_book.book.title}) [{self.status}]'
         )
+
+
+class DeclinedPairing(models.Model):
+    """
+    Records a specific book pairing that was explicitly declined so the matcher
+    will not recreate the same match on subsequent scans.
+
+    Books are stored in canonical UUID order (smaller pk first) so a single row
+    covers both directions and the unique constraint prevents duplicate entries.
+    """
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user_book_a = models.ForeignKey(
+        'inventory.UserBook',
+        on_delete=models.CASCADE,
+        related_name='declined_pairings_as_a',
+    )
+    user_book_b = models.ForeignKey(
+        'inventory.UserBook',
+        on_delete=models.CASCADE,
+        related_name='declined_pairings_as_b',
+    )
+    declined_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        verbose_name = 'Declined Pairing'
+        verbose_name_plural = 'Declined Pairings'
+        constraints = [
+            models.UniqueConstraint(
+                fields=['user_book_a', 'user_book_b'],
+                name='unique_declined_pairing',
+            )
+        ]
+        indexes = [
+            models.Index(fields=['user_book_a', 'user_book_b']),
+        ]
+
+    @classmethod
+    def record_by_ids(cls, id_x, id_y) -> None:
+        a_id, b_id = sorted([id_x, id_y], key=str)
+        cls.objects.get_or_create(user_book_a_id=a_id, user_book_b_id=b_id)
+
+    def __str__(self):
+        return f'DeclinedPairing [{self.user_book_a_id} / {self.user_book_b_id}]'

--- a/apps/matching/services/direct_matcher.py
+++ b/apps/matching/services/direct_matcher.py
@@ -261,16 +261,43 @@ def _find_book_for_trade(user_a, user_b) -> Optional[UserBook]:
     return None
 
 
+def _declined_pairing_exists(book_x_id, book_y_id) -> bool:
+    """Return True if this book pair was previously declined."""
+    from apps.matching.models import DeclinedPairing
+
+    a_id, b_id = sorted([book_x_id, book_y_id], key=str)
+    return DeclinedPairing.objects.filter(
+        user_book_a_id=a_id,
+        user_book_b_id=b_id,
+    ).exists()
+
+
 def _duplicate_match_exists(user_a, user_b, book_a: UserBook, book_b: UserBook) -> bool:
-    """Check if an equivalent active direct match already exists."""
-    existing = MatchLeg.objects.filter(
+    """Check if an equivalent active direct match already exists, or if this exact
+    pairing was previously declined."""
+    active = MatchLeg.objects.filter(
         match__status=Match.Status.PROPOSED,
         match__match_type=Match.MatchType.DIRECT,
         user_book=book_a,
         sender=user_a,
         receiver=user_b,
     ).exists()
-    return existing
+    if active:
+        return True
+    return _declined_pairing_exists(book_a.pk, book_b.pk)
+
+
+def record_declined_direct_match(match: Match) -> None:
+    """
+    Persist a DeclinedPairing for both books in a declined direct match so the
+    periodic scanner will not recreate the same pairing. Must be called inside
+    a transaction after the leg/match statuses are saved.
+    """
+    from apps.matching.models import DeclinedPairing
+
+    ub_ids = list(match.legs.values_list('user_book_id', flat=True))
+    if len(ub_ids) == 2:
+        DeclinedPairing.record_by_ids(ub_ids[0], ub_ids[1])
 
 
 @transaction.atomic

--- a/apps/matching/services/ring_detector.py
+++ b/apps/matching/services/ring_detector.py
@@ -17,6 +17,7 @@ from apps.inventory.models import UserBook, WishlistItem, condition_meets_minimu
 from apps.matching.models import Match, MatchLeg
 from apps.matching.services.direct_matcher import (
     _active_match_exists_for_user_book,
+    _declined_pairing_exists,
     user_at_match_limit,
 )
 from apps.matching.services.prioritization import (
@@ -228,6 +229,12 @@ def _try_create_ring_match(
             return None
         legs.append((sender_id, receiver_id, book_id))
 
+    # Reject the ring if any adjacent book pair was previously declined
+    n = len(legs)
+    for i in range(n):
+        if _declined_pairing_exists(legs[i][2], legs[(i + 1) % n][2]):
+            return None
+
     return _create_ring_match(legs, users)
 
 
@@ -267,6 +274,24 @@ def _create_ring_match(
     except Exception:
         logger.exception("Failed to create ring match")
         return None
+
+
+def record_declined_ring_leg(match: Match, declining_user) -> None:
+    """
+    Record the specific book edge the declining user was responsible for so the
+    matcher won't recreate a ring containing that same adjacent pairing.
+    """
+    from apps.matching.models import DeclinedPairing
+
+    try:
+        declined_leg = match.legs.get(sender=declining_user)
+    except MatchLeg.DoesNotExist:
+        return
+    try:
+        reverse_leg = match.legs.get(sender=declined_leg.receiver)
+    except MatchLeg.DoesNotExist:
+        return
+    DeclinedPairing.record_by_ids(declined_leg.user_book_id, reverse_leg.user_book_id)
 
 
 def retry_ring_after_decline(match: Match, declining_user) -> Optional[Match]:

--- a/apps/matching/tasks.py
+++ b/apps/matching/tasks.py
@@ -146,8 +146,12 @@ def retry_ring_after_decline_task(match_id: str, declining_user_id: str):
         return
 
     try:
-        from apps.matching.services.ring_detector import retry_ring_after_decline
+        from apps.matching.services.ring_detector import (
+            record_declined_ring_leg,
+            retry_ring_after_decline,
+        )
 
+        record_declined_ring_leg(match, declining_user)
         new_match = retry_ring_after_decline(match, declining_user)
         if new_match:
             from django_q.tasks import async_task

--- a/apps/matching/tests/test_declined_pairing.py
+++ b/apps/matching/tests/test_declined_pairing.py
@@ -1,0 +1,57 @@
+import pytest
+
+from apps.matching.models import DeclinedPairing
+from apps.tests.factories import BookFactory, UserBookFactory, UserFactory
+
+
+pytestmark = pytest.mark.django_db
+
+
+class TestDeclinedPairing:
+    def test_record_creates_in_canonical_order(self):
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=BookFactory())
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+
+        # Determine which id is "smaller" by string comparison
+        smaller, larger = sorted([ub_a.pk, ub_b.pk], key=str)
+        DeclinedPairing.record_by_ids(larger, smaller)  # pass in reversed order
+
+        pairing = DeclinedPairing.objects.get()
+        assert str(pairing.user_book_a_id) == str(smaller)
+        assert str(pairing.user_book_b_id) == str(larger)
+
+    def test_record_idempotent(self):
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=BookFactory())
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+
+        DeclinedPairing.record_by_ids(ub_a.pk, ub_b.pk)
+        DeclinedPairing.record_by_ids(ub_a.pk, ub_b.pk)
+
+        assert DeclinedPairing.objects.count() == 1
+
+    def test_record_reversed_args_is_idempotent(self):
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=BookFactory())
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+
+        DeclinedPairing.record_by_ids(ub_a.pk, ub_b.pk)
+        DeclinedPairing.record_by_ids(ub_b.pk, ub_a.pk)
+
+        assert DeclinedPairing.objects.count() == 1
+
+    def test_cascade_delete_on_user_book_removal(self):
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=BookFactory())
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+
+        DeclinedPairing.record_by_ids(ub_a.pk, ub_b.pk)
+        assert DeclinedPairing.objects.count() == 1
+
+        ub_a.delete()
+        assert DeclinedPairing.objects.count() == 0

--- a/apps/matching/tests/test_direct_matcher_duplicates.py
+++ b/apps/matching/tests/test_direct_matcher_duplicates.py
@@ -1,8 +1,11 @@
 import pytest
 
-from apps.matching.models import Match, MatchLeg
-from apps.matching.services.direct_matcher import _duplicate_match_exists
-from apps.tests.factories import BookFactory, UserBookFactory, UserFactory
+from apps.matching.models import DeclinedPairing, Match, MatchLeg
+from apps.matching.services.direct_matcher import (
+    _duplicate_match_exists,
+    run_direct_matching,
+)
+from apps.tests.factories import BookFactory, UserBookFactory, UserFactory, WishlistItemFactory
 
 
 pytestmark = pytest.mark.django_db
@@ -92,3 +95,45 @@ class TestDuplicateMatchExists:
         )
 
         assert not _duplicate_match_exists(user_a, user_b, ub_a, ub_b)
+
+    def test_returns_true_when_declined_pairing_exists(self):
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=BookFactory())
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+
+        DeclinedPairing.record_by_ids(ub_a.pk, ub_b.pk)
+
+        assert _duplicate_match_exists(user_a, user_b, ub_a, ub_b)
+
+    def test_returns_true_when_declined_pairing_exists_reversed(self):
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=BookFactory())
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+
+        DeclinedPairing.record_by_ids(ub_a.pk, ub_b.pk)
+
+        # Direction is irrelevant — canonical ordering means one row covers both
+        assert _duplicate_match_exists(user_b, user_a, ub_b, ub_a)
+
+    def test_periodic_scan_does_not_recreate_declined_match(self):
+        book = BookFactory()
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=book)
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+        WishlistItemFactory(user=user_b, book=book)
+        WishlistItemFactory(user=user_a, book=ub_b.book)
+
+        first_run = run_direct_matching()
+        assert len(first_run) == 1
+
+        # Simulate decline: expire the match and record the pairing
+        match = first_run[0]
+        match.status = Match.Status.EXPIRED
+        match.save(update_fields=["status"])
+        DeclinedPairing.record_by_ids(ub_a.pk, ub_b.pk)
+
+        second_run = run_direct_matching()
+        assert len(second_run) == 0

--- a/apps/matching/tests/test_match_views.py
+++ b/apps/matching/tests/test_match_views.py
@@ -1,4 +1,5 @@
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework import status
 from unittest.mock import patch
@@ -9,8 +10,10 @@ from apps.tests.factories import (
     UserBookFactory,
     MatchFactory,
     MatchLegFactory,
+    WishlistItemFactory,
 )
-from apps.matching.models import Match, MatchLeg
+from apps.matching.models import DeclinedPairing, Match, MatchLeg
+from apps.matching.services.direct_matcher import run_direct_matching
 from apps.trading.models import Trade
 
 
@@ -338,3 +341,44 @@ class TestMatchViews:
 
         assert response.status_code == status.HTTP_200_OK
         assert mock_on_commit.called
+
+    def test_decline_records_declined_pairing(self, api_client):
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=BookFactory())
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+
+        match = MatchFactory(match_type=Match.MatchType.DIRECT)
+        MatchLegFactory(match=match, sender=user_a, receiver=user_b, user_book=ub_a)
+        MatchLegFactory(match=match, sender=user_b, receiver=user_a, user_book=ub_b)
+
+        api_client.force_authenticate(user=user_a)
+        url = reverse("match-decline", kwargs={"pk": match.pk})
+        response = api_client.post(url)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert DeclinedPairing.objects.count() == 1
+        pairing = DeclinedPairing.objects.get()
+        recorded_ids = {str(pairing.user_book_a_id), str(pairing.user_book_b_id)}
+        assert recorded_ids == {str(ub_a.pk), str(ub_b.pk)}
+
+    @override_settings(MATCH_ELIGIBILITY_MIN_ACCOUNT_AGE_HOURS=0)
+    def test_decline_prevents_rematch(self, api_client):
+        book = BookFactory()
+        user_a = UserFactory()
+        user_b = UserFactory()
+        ub_a = UserBookFactory(user=user_a, book=book)
+        ub_b = UserBookFactory(user=user_b, book=BookFactory())
+        WishlistItemFactory(user=user_b, book=book)
+        WishlistItemFactory(user=user_a, book=ub_b.book)
+
+        first_run = run_direct_matching()
+        assert len(first_run) == 1
+        match = first_run[0]
+
+        api_client.force_authenticate(user=user_a)
+        url = reverse("match-decline", kwargs={"pk": match.pk})
+        api_client.post(url)
+
+        second_run = run_direct_matching()
+        assert len(second_run) == 0

--- a/apps/matching/tests/test_ring_detector.py
+++ b/apps/matching/tests/test_ring_detector.py
@@ -4,9 +4,13 @@ from django.utils import timezone
 from django.test import override_settings
 
 from apps.tests.factories import UserFactory, BookFactory, UserBookFactory, WishlistItemFactory, MatchFactory, MatchLegFactory
-from apps.matching.services.ring_detector import run_ring_detection, retry_ring_after_decline
+from apps.matching.services.ring_detector import (
+    record_declined_ring_leg,
+    run_ring_detection,
+    retry_ring_after_decline,
+)
 from apps.inventory.models import UserBook
-from apps.matching.models import Match
+from apps.matching.models import DeclinedPairing, Match, MatchLeg
 
 @pytest.mark.django_db
 class TestRingDetector:
@@ -101,3 +105,62 @@ class TestRingDetector:
         assert reformed.legs.count() == 3
         # Check D is in the reformed ring
         assert reformed.legs.filter(sender=user_d).exists()
+
+    @override_settings(MATCH_ELIGIBILITY_MIN_ACCOUNT_AGE_HOURS=0)
+    def test_ring_not_recreated_after_decline(self):
+        user_a = UserFactory(email_verified=True)
+        user_b = UserFactory(email_verified=True)
+        user_c = UserFactory(email_verified=True)
+
+        book_a = BookFactory()
+        book_b = BookFactory()
+        book_c = BookFactory()
+
+        ub_a = UserBookFactory(user=user_a, book=book_a, status=UserBook.Status.AVAILABLE)
+        WishlistItemFactory(user=user_b, book=book_a, is_active=True)
+        ub_b = UserBookFactory(user=user_b, book=book_b, status=UserBook.Status.AVAILABLE)
+        WishlistItemFactory(user=user_c, book=book_b, is_active=True)
+        ub_c = UserBookFactory(user=user_c, book=book_c, status=UserBook.Status.AVAILABLE)
+        WishlistItemFactory(user=user_a, book=book_c, is_active=True)
+
+        matches = run_ring_detection()
+        assert len(matches) == 1
+
+        # Simulate user_a declining — expire the match and record the pairing
+        match = matches[0]
+        match.status = Match.Status.EXPIRED
+        match.save(update_fields=["status"])
+        declined_leg = match.legs.get(sender=user_a)
+        reverse_leg = match.legs.get(sender=declined_leg.receiver)
+        DeclinedPairing.record_by_ids(declined_leg.user_book_id, reverse_leg.user_book_id)
+
+        second_run = run_ring_detection()
+        assert len(second_run) == 0
+
+    @override_settings(MATCH_ELIGIBILITY_MIN_ACCOUNT_AGE_HOURS=0)
+    def test_record_declined_ring_leg_records_correct_pairing(self):
+        user_a = UserFactory(email_verified=True)
+        user_b = UserFactory(email_verified=True)
+        user_c = UserFactory(email_verified=True)
+
+        book_a = BookFactory()
+        book_b = BookFactory()
+        book_c = BookFactory()
+
+        ub_a = UserBookFactory(user=user_a, book=book_a, status=UserBook.Status.AVAILABLE)
+        ub_b = UserBookFactory(user=user_b, book=book_b, status=UserBook.Status.AVAILABLE)
+        ub_c = UserBookFactory(user=user_c, book=book_c, status=UserBook.Status.AVAILABLE)
+
+        # Ring: A(ub_a)→B, B(ub_b)→C, C(ub_c)→A
+        ring_match = MatchFactory(match_type=Match.MatchType.RING, status=Match.Status.EXPIRED)
+        MatchLegFactory(match=ring_match, sender=user_a, receiver=user_b, user_book=ub_a, position=0)
+        MatchLegFactory(match=ring_match, sender=user_b, receiver=user_c, user_book=ub_b, position=1)
+        MatchLegFactory(match=ring_match, sender=user_c, receiver=user_a, user_book=ub_c, position=2)
+
+        record_declined_ring_leg(ring_match, user_a)
+
+        assert DeclinedPairing.objects.count() == 1
+        pairing = DeclinedPairing.objects.get()
+        recorded_ids = {str(pairing.user_book_a_id), str(pairing.user_book_b_id)}
+        # user_a sent ub_a; user_b (receiver) sent ub_b back — that edge is declined
+        assert recorded_ids == {str(ub_a.pk), str(ub_b.pk)}

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -210,7 +210,7 @@ class MatchDeclineView(APIView):
             match.status = Match.Status.EXPIRED
             match.save(update_fields=["status"])
 
-            # For ring matches, attempt retry
+            # For ring matches, attempt retry; for direct matches record the pairing
             if match.match_type == Match.MatchType.RING:
 
                 def _enqueue_ring_retry():
@@ -230,6 +230,11 @@ class MatchDeclineView(APIView):
 
                 transaction.on_commit(_enqueue_ring_retry)
             else:
+                from apps.matching.services.direct_matcher import (
+                    record_declined_direct_match,
+                )
+
+                record_declined_direct_match(match)
                 _notify_match_cancelled(match)
 
         return Response({"detail": "Match declined."})


### PR DESCRIPTION
## Summary

Adds a `DeclinedPairing` model to track book pairings that users have explicitly declined, preventing the matching engine from recreating the same matches on subsequent scans. This applies to both direct matches and exchange rings.

## Key Changes

- **New `DeclinedPairing` model** (`apps/matching/models.py`):
  - Stores declined book pairings in canonical UUID order (smaller pk first) so a single row covers both directions
  - Includes unique constraint and index for efficient lookups
  - Provides `record_by_ids()` class method for idempotent recording

- **Direct matcher updates** (`apps/matching/services/direct_matcher.py`):
  - Added `_declined_pairing_exists()` helper to check if a book pair was previously declined
  - Updated `_duplicate_match_exists()` to reject matches if the pairing was declined
  - Added `record_declined_direct_match()` to persist declined pairings when a direct match is declined

- **Ring detector updates** (`apps/matching/services/ring_detector.py`):
  - Added `record_declined_ring_leg()` to record the specific book edge a user declined in a ring
  - Updated `_try_create_ring_match()` to reject rings if any adjacent book pair was previously declined
  - Ensures ring retry logic records the declined pairing before attempting reformation

- **View and task updates**:
  - `MatchDeclineView` now calls `record_declined_direct_match()` for direct matches
  - `retry_ring_after_decline_task` calls `record_declined_ring_leg()` before attempting ring reformation
  - Both paths prevent the matcher from recreating the same pairing

- **Comprehensive test coverage**:
  - New `TestDeclinedPairing` class validates canonical ordering, idempotency, and cascade deletion
  - New tests in `test_ring_detector.py` verify rings are not recreated after decline
  - New tests in `test_direct_matcher_duplicates.py` verify declined pairings block rematch
  - New tests in `test_match_views.py` verify decline endpoint records pairings and prevents rematch

## Implementation Details

- Declined pairings are stored in canonical order (sorted by string representation of UUID) to ensure a single row covers both directions of a potential match
- The `record_by_ids()` method is idempotent — calling it multiple times with the same IDs (in any order) creates only one record
- Ring detection checks all adjacent book pairs in the proposed ring; if any pair was previously declined, the entire ring is rejected
- Direct matcher checks declined pairings as part of the duplicate detection logic, treating them the same as active matches

https://claude.ai/code/session_017VS9HCAVE6Qagsju3PnK21