### PR TITLE
Add match limit warning to Discovery page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,7 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
+node_modules/
 frontend/node_modules/
 
 # Frontend test results

--- a/apps/matching/views.py
+++ b/apps/matching/views.py
@@ -13,6 +13,7 @@ from apps.inventory.models import UserBook, WishlistItem
 
 from .models import Match, MatchLeg
 from .serializers import DiscoveryPartnerSerializer, MatchSerializer
+from .services.direct_matcher import user_at_match_limit
 
 logger = logging.getLogger(__name__)
 
@@ -300,13 +301,14 @@ class ReverseDiscoveryView(APIView):
 
     def get(self, request):
         user = request.user
+        at_limit = user_at_match_limit(user)
 
         # 1. Get current user's available books
         my_available_books = UserBook.objects.filter(
             user=user, status=UserBook.Status.AVAILABLE
         ).select_related("book")
         if not my_available_books.exists():
-            return Response([])
+            return Response({"at_match_limit": at_limit, "results": []})
 
         my_book_ids = list(my_available_books.values_list("book_id", flat=True))
 
@@ -400,4 +402,4 @@ class ReverseDiscoveryView(APIView):
         final_results.sort(key=lambda x: len(x["they_want"]), reverse=True)
 
         serializer = DiscoveryPartnerSerializer(final_results, many=True)
-        return Response(serializer.data)
+        return Response({"at_match_limit": at_limit, "results": serializer.data})

--- a/frontend/src/pages/Discovery.jsx
+++ b/frontend/src/pages/Discovery.jsx
@@ -12,11 +12,14 @@ export default function Discovery() {
   const queryClient = useQueryClient();
   const [addedToWishlist, setAddedToWishlist] = useState(new Set());
 
-  const { data: partners, isLoading, isError, error, refetch } = useQuery({
+  const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['discovery-partners'],
     queryFn: () => matchesApi.reverseDiscovery().then((r) => r.data),
     staleTime: 1000 * 60 * 5, // 5 minutes
   });
+
+  const partners = data?.results ?? [];
+  const atMatchLimit = data?.at_match_limit ?? false;
 
   const addToWishlistMutation = useMutation({
     mutationFn: ({ identifier }) => wishlistApi.add({ isbn: identifier }),
@@ -44,6 +47,12 @@ export default function Discovery() {
           These users want books you have available. Browse their collections to find something you want in return!
         </p>
       </div>
+
+      {atMatchLimit && (
+        <div className={styles.limitWarning} role="alert">
+          <strong>Match limit reached.</strong> You have too many active matches or proposals to start a new trade right now. Complete or cancel an existing one to free up a slot.
+        </div>
+      )}
 
       {partners.length === 0 ? (
         <div className={styles.empty}>

--- a/frontend/src/pages/Discovery.module.css
+++ b/frontend/src/pages/Discovery.module.css
@@ -110,6 +110,17 @@
   width: 100%;
 }
 
+.limitWarning {
+  background-color: #fffbeb;
+  border: 1px solid #f59e0b;
+  border-radius: 0.375rem;
+  color: #92400e;
+  padding: 0.875rem 1.25rem;
+  margin-top: 1.5rem;
+  font-size: 0.9375rem;
+  line-height: 1.5;
+}
+
 .empty {
   text-align: center;
   padding: 4rem 2rem;

--- a/frontend/src/pages/Discovery.test.jsx
+++ b/frontend/src/pages/Discovery.test.jsx
@@ -64,7 +64,7 @@ describe('Discovery Page', () => {
   });
 
   it('renders empty state when no partners found', async () => {
-    matchesApi.reverseDiscovery.mockResolvedValue({ data: [] });
+    matchesApi.reverseDiscovery.mockResolvedValue({ data: { at_match_limit: false, results: [] } });
     render(<Discovery />, { wrapper });
     expect(await screen.findByText(/no potential partners found yet/i)).toBeInTheDocument();
   });
@@ -76,7 +76,7 @@ describe('Discovery Page', () => {
   });
 
   it('renders partners and their books correctly', async () => {
-    matchesApi.reverseDiscovery.mockResolvedValue({ data: mockPartners });
+    matchesApi.reverseDiscovery.mockResolvedValue({ data: { at_match_limit: false, results: mockPartners } });
     render(<Discovery />, { wrapper });
 
     expect(await screen.findByText('@partner1')).toBeInTheDocument();
@@ -86,8 +86,22 @@ describe('Discovery Page', () => {
     expect(screen.getByRole('button', { name: /i want this/i })).toBeInTheDocument();
   });
 
+  it('shows a warning banner when the user is at their match limit', async () => {
+    matchesApi.reverseDiscovery.mockResolvedValue({ data: { at_match_limit: true, results: mockPartners } });
+    render(<Discovery />, { wrapper });
+    expect(await screen.findByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/match limit reached/i)).toBeInTheDocument();
+  });
+
+  it('does not show the warning banner when the user is under their match limit', async () => {
+    matchesApi.reverseDiscovery.mockResolvedValue({ data: { at_match_limit: false, results: mockPartners } });
+    render(<Discovery />, { wrapper });
+    await screen.findByText('@partner1');
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
   it('allows adding a book to wishlist', async () => {
-    matchesApi.reverseDiscovery.mockResolvedValue({ data: mockPartners });
+    matchesApi.reverseDiscovery.mockResolvedValue({ data: { at_match_limit: false, results: mockPartners } });
     wishlistApi.add.mockResolvedValue({ data: {} });
     
     render(<Discovery />, { wrapper });


### PR DESCRIPTION
## Summary
Adds a visual warning banner to the Discovery page when a user has reached their match capacity limit, preventing them from initiating new trades until they complete or cancel existing matches.

## Changes

### Backend (`apps/matching/views.py`)
- Modified `ReverseDiscoveryView.get()` to check user match capacity via `user_at_match_limit()`
- Updated response format from a flat list to a structured object: `{"at_match_limit": bool, "results": [...]}`
- Applied consistently to both early return (no available books) and final response paths

### Frontend (`frontend/src/pages/Discovery.jsx`)
- Updated query hook to destructure the new response structure
- Extracted `partners` and `atMatchLimit` from the nested `data` object
- Added conditional rendering of a warning banner when `atMatchLimit` is true

### Styling (`frontend/src/pages/Discovery.module.css`)
- Added `.limitWarning` class with amber/warning color scheme (`#fffbeb` background, `#f59e0b` border, `#92400e` text)
- Styled as an alert box with padding, border-radius, and appropriate typography

### Tests (`frontend/src/pages/Discovery.test.jsx`)
- Updated all existing mock responses to match new API structure
- Added test for warning banner visibility when at match limit
- Added test confirming banner is hidden when under match limit
- Updated existing test for wishlist functionality to use new response format

## Implementation Details
- The warning message informs users they have "too many active matches or proposals" and instructs them to "complete or cancel an existing one"
- Uses semantic HTML `role="alert"` for accessibility
- Matches existing design patterns with warning-level styling (amber color palette)
- No changes to match capacity calculation logic — only surface-level exposure of existing backend check

https://claude.ai/code/session_01Qa9XL3R2p21VdCKPizNWRG