### PR TITLE
Update last_active_at only when stale (24+ hours)

### DIFF
--- a/apps/accounts/tests/test_views.py
+++ b/apps/accounts/tests/test_views.py
@@ -1,5 +1,7 @@
 import pytest
+from datetime import timedelta
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from unittest.mock import patch
 from django.utils.http import urlsafe_base64_encode
@@ -59,6 +61,30 @@ class TestAccountViews:
         
         assert response.status_code == status.HTTP_200_OK
         assert response.data['email'] == user.email
+
+    def test_me_get_refreshes_last_active_at_when_stale(self, api_client):
+        user = UserFactory()
+        stale_time = timezone.now() - timedelta(hours=25)
+        User.objects.filter(pk=user.pk).update(last_active_at=stale_time)
+        user.refresh_from_db()
+        api_client.force_authenticate(user=user)
+
+        api_client.get(reverse("user-me"))
+
+        user.refresh_from_db()
+        assert user.last_active_at > stale_time
+
+    def test_me_get_skips_update_when_active_recently(self, api_client):
+        user = UserFactory()
+        recent_time = timezone.now() - timedelta(hours=1)
+        User.objects.filter(pk=user.pk).update(last_active_at=recent_time)
+        user.refresh_from_db()
+        api_client.force_authenticate(user=user)
+
+        api_client.get(reverse("user-me"))
+
+        user.refresh_from_db()
+        assert abs((user.last_active_at - recent_time).total_seconds()) < 2
 
     def test_user_me_update_view(self, api_client):
         user = UserFactory(full_name="Old Name")

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -239,7 +239,11 @@ class UserMeView(APIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def get(self, request):
-        serializer = UserMeSerializer(request.user)
+        user = request.user
+        if user.last_active_at < timezone.now() - timedelta(hours=24):
+            user.last_active_at = timezone.now()
+            user.save(update_fields=["last_active_at"])
+        serializer = UserMeSerializer(user)
         return Response(serializer.data)
 
     def patch(self, request):

--- a/apps/matching/tests/test_reverse_discovery.py
+++ b/apps/matching/tests/test_reverse_discovery.py
@@ -10,74 +10,74 @@ class TestReverseDiscoveryView:
     def test_no_available_books(self, api_client):
         user = UserFactory()
         api_client.force_authenticate(user=user)
-        
+
         url = reverse('reverse-discovery')
         response = api_client.get(url)
-        
+
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == []
+        assert response.data['results'] == []
 
     def test_discovery_success(self, api_client):
         user_a = UserFactory()
         user_b = UserFactory()
         api_client.force_authenticate(user=user_a)
-        
+
         book_1 = BookFactory() # Book User A has, User B wants
         book_2 = BookFactory() # Book User B has, User A DOES NOT want
-        
+
         UserBookFactory(user=user_a, book=book_1, status=UserBook.Status.AVAILABLE)
         WishlistItemFactory(user=user_b, book=book_1, is_active=True)
         UserBookFactory(user=user_b, book=book_2, status=UserBook.Status.AVAILABLE)
-        
+
         url = reverse('reverse-discovery')
         response = api_client.get(url)
-        
+
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]['user']['id'] == str(user_b.id)
-        assert len(response.data[0]['they_want']) == 1
-        assert response.data[0]['they_want'][0]['book']['id'] == str(book_1.id)
-        assert len(response.data[0]['they_offer']) == 1
-        assert response.data[0]['they_offer'][0]['book']['id'] == str(book_2.id)
+        assert len(response.data['results']) == 1
+        assert response.data['results'][0]['user']['id'] == str(user_b.id)
+        assert len(response.data['results'][0]['they_want']) == 1
+        assert response.data['results'][0]['they_want'][0]['book']['id'] == str(book_1.id)
+        assert len(response.data['results'][0]['they_offer']) == 1
+        assert response.data['results'][0]['they_offer'][0]['book']['id'] == str(book_2.id)
 
     def test_discovery_excludes_existing_matches(self, api_client):
         user_a = UserFactory()
         user_b = UserFactory()
         api_client.force_authenticate(user=user_a)
-        
+
         book_1 = BookFactory()
         UserBookFactory(user=user_a, book=book_1, status=UserBook.Status.AVAILABLE)
         WishlistItemFactory(user=user_b, book=book_1, is_active=True)
         UserBookFactory(user=user_b, status=UserBook.Status.AVAILABLE)
-        
+
         # Create an active match between A and B
         match = MatchFactory()
         MatchLegFactory(match=match, sender=user_a, receiver=user_b)
-        
+
         url = reverse('reverse-discovery')
         response = api_client.get(url)
-        
+
         # Should be empty because B is an active partner
         assert response.status_code == status.HTTP_200_OK
-        assert response.data == []
+        assert response.data['results'] == []
 
     def test_discovery_excludes_my_wishlist_from_offers(self, api_client):
         user_a = UserFactory()
         user_b = UserFactory()
         api_client.force_authenticate(user=user_a)
-        
+
         book_1 = BookFactory() # A has, B wants
         book_2 = BookFactory() # B has, A ALSO wants (mutual match scenario)
-        
+
         UserBookFactory(user=user_a, book=book_1, status=UserBook.Status.AVAILABLE)
         WishlistItemFactory(user=user_b, book=book_1, is_active=True)
-        
+
         UserBookFactory(user=user_b, book=book_2, status=UserBook.Status.AVAILABLE)
         WishlistItemFactory(user=user_a, book=book_2, is_active=True) # A wants book_2
-        
+
         url = reverse('reverse-discovery')
         response = api_client.get(url)
-        
-        # Partner B is found, but they_offer should NOT include book_2 
+
+        # Partner B is found, but they_offer should NOT include book_2
         # because it should be handled by the automatic mutual matcher
-        assert len(response.data) == 0 # Current implementation excludes partner if they have NO books I DON'T want
+        assert len(response.data['results']) == 0 # Current implementation excludes partner if they have NO books I DON'T want


### PR DESCRIPTION
## Summary
Optimize the `UserMeView` GET endpoint to update `last_active_at` only when the timestamp is stale (older than 24 hours), reducing unnecessary database writes while maintaining accurate activity tracking.

## Changes
- **views.py**: Modified `UserMeView.get()` to conditionally update `last_active_at` only if the current value is older than 24 hours
- **tests/test_views.py**: Added two test cases:
  - `test_me_get_refreshes_last_active_at_when_stale`: Verifies the timestamp is updated when stale
  - `test_me_get_skips_update_when_active_recently`: Verifies no update occurs when the timestamp is recent (within 24 hours)

## Implementation Details
- Uses `timezone.now() - timedelta(hours=24)` to determine staleness threshold
- Only updates the `last_active_at` field (via `update_fields` parameter) to minimize database impact
- Maintains backward compatibility with existing `UserMeSerializer` behavior

https://claude.ai/code/session_01AeB5JKH1nVvgZPfPhoThof