### PR TITLE
Reorder book enrichment checks and add logging for unfound ISBNs

### DIFF
--- a/apps/books/services/openlibrary.py
+++ b/apps/books/services/openlibrary.py
@@ -165,6 +165,13 @@ def get_or_create_book(isbn: str, minimal: bool = False):
 
 def _book_needs_enrichment(book) -> bool:
     """Return True when cached book metadata is incomplete enough to re-fetch."""
+    # Apply throttle first — including placeholder-title books — so a permanently
+    # unknown ISBN doesn't get re-fetched on every request.
+    if book.last_enriched_at:
+        throttle_limit = timezone.now() - timedelta(days=ENRICHMENT_THROTTLE_DAYS)
+        if book.last_enriched_at > throttle_limit:
+            return False
+
     if _is_placeholder_title(book.title):
         return True
 
@@ -172,14 +179,6 @@ def _book_needs_enrichment(book) -> bool:
     is_complete = book.authors and book.physical_format and book.description
     if is_complete:
         return False
-
-    # Less aggressive re-enrichment:
-    # If we tried to enrich recently (within the throttle window), don't try again.
-    # This prevents hammering the API for books that Open Library simply doesn't have data for.
-    if book.last_enriched_at:
-        throttle_limit = timezone.now() - timedelta(days=ENRICHMENT_THROTTLE_DAYS)
-        if book.last_enriched_at > throttle_limit:
-            return False
 
     return True
 
@@ -235,6 +234,14 @@ def _update_book_from_data(book, data: dict) -> None:
         book.save(update_fields=content_fields)
     else:
         book.save(update_fields=["last_enriched_at"])
+
+    if _is_placeholder_title(book.title):
+        logger.warning(
+            "ISBN %s still has a placeholder title after enrichment; "
+            "Open Library may not have data for this ISBN. "
+            "Consider adding a manual override to KNOWN_ISBN_METADATA_OVERRIDES.",
+            book.isbn_13,
+        )
 
 
 def normalize_isbn(isbn: str) -> str | None:


### PR DESCRIPTION
## Summary
Improves the book enrichment logic by applying the throttle check earlier in the decision flow and adds warning-level logging when an ISBN remains unfound after enrichment attempts.

## Key Changes
- **Reorder enrichment checks**: Move the throttle check to the beginning of `_book_needs_enrichment()` so that permanently unknown ISBNs (with placeholder titles) are not re-fetched on every request. This prevents unnecessary API calls for books Open Library doesn't have data for.
- **Add logging for unfound ISBNs**: When a book still has a placeholder title after enrichment, log a warning that suggests adding a manual override to `KNOWN_ISBN_METADATA_OVERRIDES`. This helps operators identify ISBNs that need manual intervention.

## Implementation Details
The throttle check now runs before the placeholder title check, ensuring that:
1. If we've recently attempted enrichment (within `ENRICHMENT_THROTTLE_DAYS`), we skip re-fetching regardless of whether the title is a placeholder
2. This prevents hammering the Open Library API for ISBNs that don't exist in their database
3. The warning log provides actionable guidance for handling persistently unfound ISBNs

https://claude.ai/code/session_01U6WBGHaR23Gpsj17HHp8Rd