### PR TITLE
fix: remove false-positive backup detection and fix bare storage isinstance check

### DIFF
--- a/apps/backups/services/backup_service.py
+++ b/apps/backups/services/backup_service.py
@@ -31,9 +31,9 @@ def _ensure_filesystem_storage_path_exists(storage_backend) -> None:
     Only acts on FileSystemStorage — S3-compatible backends use a location
     prefix, not a local path, so os.makedirs would create a spurious directory.
     """
-    underlying = getattr(storage_backend, "storage", None)
-    # Only create directories for real filesystem storage. S3Boto3Storage uses
-    # "location" as an S3 key prefix (e.g. "db-backups"), not a local path.
+    # Use storage_backend itself as the fallback so a bare (unwrapped)
+    # FileSystemStorage is handled correctly alongside dbbackup's wrapper.
+    underlying = getattr(storage_backend, "storage", storage_backend)
     if not isinstance(underlying, FileSystemStorage):
         return
     location = getattr(underlying, "location", None)
@@ -114,18 +114,16 @@ def run_database_backup(record_id: str) -> None:
 
         after: set[str] = set(storage.list_backups())
         new_files = after - before
-        filename = new_files.pop() if new_files else ""
-
-        if not filename and after:
-            # Before/after diff found nothing new (can happen when cleanup
-            # removes an old file and the filenames sort ambiguously). Fall
-            # back to the lexicographically largest name; backup filenames are
-            # timestamped so max == most recent.
-            filename = max(after)
-            logger.warning(
-                "Could not detect new backup via list diff; "
-                "falling back to most recent file: %s", filename
+        if not new_files:
+            # The set difference is empty: dbbackup did not create a new file.
+            # Do NOT fall back to an existing backup — that would silently
+            # report a stale file as a fresh backup (false positive).
+            raise RuntimeError(
+                "Backup command completed but no new file was detected in storage. "
+                "dbbackup may have failed silently or the before/after file lists "
+                "are identical. Check dbbackup and storage configuration."
             )
+        filename = new_files.pop()
 
         # Verify the file is actually reachable in storage.
         if filename:

--- a/apps/backups/tests/test_backup_service.py
+++ b/apps/backups/tests/test_backup_service.py
@@ -73,20 +73,20 @@ class TestBackupService:
 
     @patch("apps.backups.services.backup_service.get_storage")
     @patch("apps.backups.services.backup_service.call_command")
-    def test_fallback_to_max_filename_when_diff_empty(self, mock_call, mock_get_storage):
-        """If before==after (no new file detected), fall back to max filename."""
+    def test_empty_diff_raises_not_false_positive(self, mock_call, mock_get_storage):
+        """If before==after (no new file detected), raise rather than picking an old backup."""
         record = BackupRecordFactory(status=BackupRecord.Status.PENDING)
         existing = ["backup-2024-01-01.psql", "backup-2024-01-02.psql"]
         mock_get_storage.return_value = _make_mock_storage(
             before=existing,
-            after=existing,  # diff is empty — cleanup removed an old file
+            after=existing,  # diff is empty — dbbackup produced nothing new
         )
 
-        run_database_backup(str(record.pk))
+        with pytest.raises(RuntimeError, match="no new file was detected"):
+            run_database_backup(str(record.pk))
 
         record.refresh_from_db()
-        assert record.status == BackupRecord.Status.SUCCESS
-        assert record.file_name == "backup-2024-01-02.psql"  # max of the list
+        assert record.status == BackupRecord.Status.FAILED
 
     @patch("apps.backups.services.backup_service.get_storage")
     def test_run_database_backup_failure(self, mock_get_storage):


### PR DESCRIPTION
## Summary

Two bugs found in post-merge review of #105:

- **Logic error (high risk):** The `max(after)` fallback in `run_database_backup()` would silently report a stale existing backup as a fresh SUCCESS when `before == after` (i.e. dbbackup produced no new file). Removed the fallback — an empty set difference now raises `RuntimeError`, which is caught and recorded as FAILED.
- **Minor:** `_ensure_filesystem_storage_path_exists` used `getattr(backend, "storage", None)` so a bare (unwrapped) `FileSystemStorage` would resolve to `None` and skip directory creation. Fallback changed to `storage_backend` itself so both wrapped and unwrapped cases are handled.

## Test plan

- [ ] `pytest apps/backups/` passes — the empty-diff test now asserts `FAILED + RuntimeError` instead of the previous (incorrect) `SUCCESS`
- [ ] Trigger a manual backup from the admin and confirm it still completes successfully

https://claude.ai/code/session_01UgrZ1FasSJ5EcCGvPm6ubB

---
_Generated by [Claude Code](https://claude.ai/code/session_01UgrZ1FasSJ5EcCGvPm6ubB)_