### PR TITLE
Add Nix package manager fallback paths for PostgreSQL tools

### DIFF
--- a/apps/backups/tests/test_find_pg_tool.py
+++ b/apps/backups/tests/test_find_pg_tool.py
@@ -1,0 +1,46 @@
+import pytest
+from unittest.mock import patch
+
+from config.settings.base import _find_pg_tool
+
+
+@pytest.mark.unit
+class TestFindPgTool:
+    def test_found_on_path(self):
+        with patch("config.settings.base.shutil.which", return_value="/usr/bin/pg_dump"):
+            assert _find_pg_tool("pg_dump") == "/usr/bin/pg_dump"
+
+    def test_debian_apt_fallback(self):
+        # Matches /usr/lib/postgresql/14/bin/pg_dump (first existing version wins)
+        target = "/usr/lib/postgresql/14/bin/pg_dump"
+        with (
+            patch("config.settings.base.shutil.which", return_value=None),
+            patch("config.settings.base.os.path.isfile", side_effect=lambda p: p == target),
+        ):
+            assert _find_pg_tool("pg_dump") == target
+
+    def test_nix_profile_fallback(self):
+        target = "/root/.nix-profile/bin/pg_dump"
+        with (
+            patch("config.settings.base.shutil.which", return_value=None),
+            patch("config.settings.base.os.path.isfile", side_effect=lambda p: p == target),
+            patch("config.settings.base.glob.glob", return_value=[]),
+        ):
+            assert _find_pg_tool("pg_dump") == target
+
+    def test_nix_store_glob_fallback(self):
+        store_path = "/nix/store/abc123-postgresql-14/bin/pg_dump"
+        with (
+            patch("config.settings.base.shutil.which", return_value=None),
+            patch("config.settings.base.os.path.isfile", return_value=False),
+            patch("config.settings.base.glob.glob", return_value=[store_path]),
+        ):
+            assert _find_pg_tool("pg_dump") == store_path
+
+    def test_bare_name_fallback_when_not_found(self):
+        with (
+            patch("config.settings.base.shutil.which", return_value=None),
+            patch("config.settings.base.os.path.isfile", return_value=False),
+            patch("config.settings.base.glob.glob", return_value=[]),
+        ):
+            assert _find_pg_tool("pg_dump") == "pg_dump"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import shutil
 from datetime import timedelta
@@ -262,10 +263,23 @@ DBBACKUP_STORAGE_OPTIONS = {"location": str(BASE_DIR / "backups")}
 def _find_pg_tool(name: str) -> str:
     if path := shutil.which(name):
         return path
+    # Debian/Ubuntu apt paths (/usr/lib/postgresql/<version>/bin/)
     for version in range(18, 11, -1):
         candidate = f"/usr/lib/postgresql/{version}/bin/{name}"
         if os.path.isfile(candidate):
             return candidate
+    # Nix profile paths (Railway/Nixpacks runtime)
+    for nix_profile in (
+        "/root/.nix-profile/bin",
+        "/nix/var/nix/profiles/default/bin",
+    ):
+        candidate = f"{nix_profile}/{name}"
+        if os.path.isfile(candidate):
+            return candidate
+    # Nix store glob (hash changes per build, so match any version)
+    matches = glob.glob(f"/nix/store/*-postgresql-*/bin/{name}")
+    if matches:
+        return matches[0]
     return name  # fall back to bare name; will fail with a clear OS error if missing
 
 DBBACKUP_CONNECTORS = {


### PR DESCRIPTION
## Summary

Extends the `_find_pg_tool()` function to support PostgreSQL tool discovery on Nix-based systems (Railway/Nixpacks runtime), in addition to the existing Debian/Ubuntu apt paths.

## Changes

- **Added Nix profile path support**: Checks `/root/.nix-profile/bin` and `/nix/var/nix/profiles/default/bin` for PostgreSQL tools
- **Added Nix store glob fallback**: Uses glob pattern matching to find PostgreSQL tools in `/nix/store/*-postgresql-*/bin/` (handles hash-based versioning in Nix store)
- **Maintained fallback chain**: Preserves existing behavior (PATH → Debian apt → Nix profile → Nix store glob → bare name)
- **Added comprehensive test coverage**: New test file `apps/backups/tests/test_find_pg_tool.py` with unit tests for all discovery paths

## Implementation Details

The function now attempts discovery in this order:
1. `shutil.which()` — system PATH
2. Debian/Ubuntu versioned paths (`/usr/lib/postgresql/{18..12}/bin/`)
3. Nix profile paths (fixed locations)
4. Nix store glob pattern (handles dynamic hash-based paths)
5. Bare tool name (will fail with clear OS error if missing)

This enables backup functionality on Railway and other Nix-based deployment platforms without requiring manual tool path configuration.

https://claude.ai/code/session_01N2aY3SqdsUxJdoDGcp4rJg