### PR TITLE
Add peer-to-peer gifting for individual users

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -53,7 +53,7 @@ bookforbook/
 │   ├── inventory/                   # UserBooks (have-list), WishlistItems (want-list)
 │   ├── matching/                    # Match detection engine (direct + ring)
 │   ├── trading/                     # Proposals, Trades, Shipments
-│   ├── donations/                   # Institutional donation workflow
+│   ├── donations/                   # One-directional gifting (individual→institution or individual→individual)
 │   ├── ratings/                     # Rating system + rolling average
 │   ├── notifications/               # Email/in-app notifications, Django-Q2 tasks
 │   ├── messaging/                   # Structured trade messages
@@ -111,8 +111,9 @@ All primary keys are UUIDs. All personal address fields are encrypted at rest.
 ### TradeProposal + TradeProposalItem (user-initiated)
 - Always 1-for-1: exactly one item in each direction (enforce at API level)
 
-### Donation (institutional, one-directional)
-- Separate from trades: no shipping address needed for the institution as receiver
+### Donation (one-directional gift/donation)
+- `recipient` FK accepts any active user: institutions (must be `is_verified=True`) or individuals (book must be on their active wishlist)
+- Donor's address revealed to recipient after acceptance; recipient's address revealed to donor after acceptance
 
 ### Trade (execution record, created after confirmation)
 - `source_type`: `match` | `proposal` | `donation`
@@ -142,7 +143,7 @@ All endpoints under `/api/v1/`. JWT auth required except browse/search/public pr
 auth/           register, verify-email, login, refresh, password-reset
 users/          me (CRUD + export + delete), :id/ (public profile), :id/ratings/
 books/          lookup/ (ISBN), :id/, search/
-my-books/       GET/POST/PATCH/DELETE (have-list)
+my-books/       GET/POST/PATCH/DELETE (have-list), :id/wanted-by/ (gift recipient list)
 wishlist/       GET/POST/PATCH/DELETE (want-list)
 matches/        list, discovery/reverse/, :id/, :id/accept/, :id/decline/
 proposals/      list, create, :id/, accept, decline

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Background tasks are defined in `tasks.py` per app and dispatched via `django_q.
 | `inventory` | `UserBook` (have-list) and `WishlistItem` (want-list) |
 | `matching` | Direct match and exchange ring detection; triggered on new UserBook/WishlistItem and on a 6-hour periodic scan |
 | `trading` | `TradeProposal`, `Trade`, `TradeShipment`, `TradeMessage`; shipment tracking and trade lifecycle |
-| `donations` | One-directional book donations to institutional accounts |
+| `donations` | One-directional gifting: individual → institution (donation) or individual → individual (gift). `Donation.recipient` FK accepts any active user; individual recipients must have the book on their active wishlist. Institutional recipients must be `is_verified=True`. |
 | `ratings` | 1–5 star ratings; rolling average over last 10 ratings via `apps/ratings/services/rolling_average.py` |
 | `notifications` | Email and in-app notifications dispatched as Django-Q2 tasks |
 | `messaging` | Structured trade messages (not free-form chat) |
@@ -116,7 +116,7 @@ Trade confirmed → 3-week auto-close timer starts
 
 ### Institutional accounts (libraries/bookstores)
 
-Institutions require admin approval (`is_verified=True`) before participating. They are excluded from automated match detection but **can** list books on their have-list and participate in manual trade proposals. They also receive donations.
+Institutions require admin approval (`is_verified=True`) before participating. They are excluded from automated match detection but **can** list books on their have-list and participate in manual trade proposals. They also receive donations/gifts via the `Donation` model.
 
 ### Frontend (`frontend/`)
 

--- a/README.md
+++ b/README.md
@@ -453,14 +453,14 @@ Individual users can offer a donation directly to your institution:
 ```
 POST /api/v1/donations/
 {
-  "institution_id": "library-uuid",
+  "recipient_id": "library-uuid",
   "user_book_id": "book-uuid"
 }
 ```
 
 You review incoming donation offers:
 ```
-GET /api/v1/donations/
+GET /api/v1/donations/?direction=received
 ```
 
 **Accept:**
@@ -473,7 +473,27 @@ POST /api/v1/donations/{id}/accept/
 POST /api/v1/donations/{id}/decline/
 ```
 
-Once accepted, the donor ships the book to your institution. No address reveal is needed on your end — the donor sees your institution's public address.
+Once accepted, the donor ships the book to your institution. Your shipping address is revealed to the donor after you accept.
+
+### Peer-to-peer Gifting (Individuals)
+
+Individual users can also gift books directly to other individuals whose wishlist includes the book — no trade required.
+
+```
+POST /api/v1/donations/
+{
+  "recipient_id": "individual-user-uuid",
+  "user_book_id": "book-uuid"
+}
+```
+
+The book must be on the recipient's active wishlist. To discover who wants a specific book you own:
+
+```
+GET /api/v1/my-books/{user-book-id}/wanted-by/
+```
+
+Returns a list of potential recipients (individuals + verified institutions) with their wishlist preferences.
 
 ---
 

--- a/apps/accounts/management/commands/seed_e2e.py
+++ b/apps/accounts/management/commands/seed_e2e.py
@@ -630,23 +630,23 @@ class Command(BaseCommand):
 
         self._seed_one_donation(
             donor=users["alice"],
-            institution=library,
+            recipient=library,
             user_book=inventory["alice_austen"],
             message="Hope this helps your collection!",
             label="Donation 1 (alice→library)",
         )
         self._seed_one_donation(
             donor=users["bob"],
-            institution=library,
+            recipient=library,
             user_book=inventory["bob_tolstoy"],
             message="Happy to donate this one!",
             label="Donation 2 (bob→library)",
         )
 
-    def _seed_one_donation(self, donor, institution, user_book, message, label):
+    def _seed_one_donation(self, donor, recipient, user_book, message, label):
         existing = Donation.objects.filter(
             donor=donor,
-            institution=institution,
+            recipient=recipient,
             user_book=user_book,
             status=Donation.Status.OFFERED,
         ).first()
@@ -655,7 +655,7 @@ class Command(BaseCommand):
             return
         Donation.objects.create(
             donor=donor,
-            institution=institution,
+            recipient=recipient,
             user_book=user_book,
             status=Donation.Status.OFFERED,
             message=message,

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -442,7 +442,7 @@ class UserWantedBooksView(APIView):
         except User.DoesNotExist:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
 
-        from apps.inventory.models import WishlistItem
+        from apps.inventory.models import UserBook, WishlistItem
         from apps.inventory.serializers import WishlistItemSerializer
 
         items = (
@@ -450,7 +450,26 @@ class UserWantedBooksView(APIView):
             .select_related("book")
             .order_by("-created_at")
         )
-        serializer = WishlistItemSerializer(items, many=True)
+
+        viewer_book_id_map = {}
+        if request.user.is_authenticated and request.user != user:
+            book_ids = items.values_list('book_id', flat=True)
+            viewer_books = (
+                UserBook.objects.filter(
+                    user=request.user,
+                    status=UserBook.Status.AVAILABLE,
+                    book_id__in=book_ids,
+                )
+                .values('book_id', 'id')
+                .order_by('created_at')
+            )
+            for vb in viewer_books:
+                if vb['book_id'] not in viewer_book_id_map:
+                    viewer_book_id_map[vb['book_id']] = vb['id']
+
+        serializer = WishlistItemSerializer(
+            items, many=True, context={'viewer_book_id_map': viewer_book_id_map}
+        )
         return Response(serializer.data)
 
 

--- a/apps/donations/admin.py
+++ b/apps/donations/admin.py
@@ -5,9 +5,9 @@ from .models import Donation
 
 @admin.register(Donation)
 class DonationAdmin(admin.ModelAdmin):
-    list_display = ['donor', 'institution', 'user_book', 'status', 'created_at']
+    list_display = ['donor', 'recipient', 'user_book', 'status', 'created_at']
     list_filter = ['status']
-    search_fields = ['donor__username', 'institution__username', 'institution__institution_name']
+    search_fields = ['donor__username', 'recipient__username', 'recipient__institution_name']
     ordering = ['-created_at']
     readonly_fields = ['id', 'created_at', 'updated_at']
-    raw_id_fields = ['donor', 'institution', 'user_book']
+    raw_id_fields = ['donor', 'recipient', 'user_book']

--- a/apps/donations/migrations/0002_rename_institution_to_recipient.py
+++ b/apps/donations/migrations/0002_rename_institution_to_recipient.py
@@ -1,0 +1,16 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('donations', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='Donation',
+            old_name='institution',
+            new_name='recipient',
+        ),
+    ]

--- a/apps/donations/models.py
+++ b/apps/donations/models.py
@@ -18,7 +18,7 @@ class Donation(models.Model):
         on_delete=models.CASCADE,
         related_name='donations_given',
     )
-    institution = models.ForeignKey(
+    recipient = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
         related_name='donations_received',
@@ -39,7 +39,8 @@ class Donation(models.Model):
         ordering = ['-created_at']
 
     def __str__(self):
+        display = getattr(self.recipient, 'institution_name', None) or self.recipient.username
         return (
-            f'Donation: {self.donor.username} → {self.institution.institution_name or self.institution.username} '
+            f'Donation: {self.donor.username} → {display} '
             f'({self.user_book.book.title}) [{self.status}]'
         )

--- a/apps/donations/serializers.py
+++ b/apps/donations/serializers.py
@@ -8,16 +8,16 @@ from .models import Donation
 
 class DonationSerializer(serializers.ModelSerializer):
     donor = UserPublicProfileSerializer(read_only=True)
-    institution = UserPublicProfileSerializer(read_only=True)
+    recipient = UserPublicProfileSerializer(read_only=True)
     user_book = UserBookSerializer(read_only=True)
-    institution_address = serializers.SerializerMethodField()
+    recipient_address = serializers.SerializerMethodField()
     is_recipient = serializers.SerializerMethodField()
 
     class Meta:
         model = Donation
         fields = [
-            'id', 'donor', 'institution', 'user_book',
-            'status', 'message', 'institution_address', 'is_recipient',
+            'id', 'donor', 'recipient', 'user_book',
+            'status', 'message', 'recipient_address', 'is_recipient',
             'created_at', 'updated_at',
         ]
         read_only_fields = fields
@@ -26,58 +26,71 @@ class DonationSerializer(serializers.ModelSerializer):
         request = self.context.get('request')
         if not request or not request.user.is_authenticated:
             return False
-        return request.user == obj.institution
+        return request.user == obj.recipient
 
-    def get_institution_address(self, obj):
-        """Reveal institution address only after donation is accepted."""
+    def get_recipient_address(self, obj):
+        """Reveal recipient address only after donation is accepted."""
         request = self.context.get('request')
         if not request or not request.user.is_authenticated:
             return None
         if obj.status not in [Donation.Status.ACCEPTED, Donation.Status.SHIPPED, Donation.Status.RECEIVED]:
             return None
-        if request.user != obj.donor and request.user != obj.institution:
+        if request.user != obj.donor and request.user != obj.recipient:
             return None
-        # Reveal institution's address to the donor
         if request.user == obj.donor:
-            institution = obj.institution
+            r = obj.recipient
             return {
-                'institution_name': institution.institution_name,
-                'full_name': institution.full_name,
-                'address_line_1': institution.address_line_1,
-                'address_line_2': institution.address_line_2,
-                'city': institution.city,
-                'state': institution.state,
-                'zip_code': institution.zip_code,
+                'institution_name': getattr(r, 'institution_name', None),
+                'full_name': r.full_name,
+                'address_line_1': r.address_line_1,
+                'address_line_2': r.address_line_2,
+                'city': r.city,
+                'state': r.state,
+                'zip_code': r.zip_code,
             }
         return None
 
 
 class DonationCreateSerializer(serializers.Serializer):
-    institution_id = serializers.UUIDField()
+    recipient_id = serializers.UUIDField()
     user_book_id = serializers.UUIDField()
     message = serializers.CharField(required=False, allow_blank=True, max_length=1000)
 
     def validate(self, attrs):
         from apps.accounts.models import User
-        from apps.inventory.models import UserBook
+        from apps.inventory.models import UserBook, WishlistItem
 
         request = self.context['request']
         donor = request.user
 
-        # Validate institution
         try:
-            institution = User.objects.get(
-                pk=attrs['institution_id'],
-                account_type__in=[User.AccountType.LIBRARY, User.AccountType.BOOKSTORE],
-                is_verified=True,
-                is_active=True,
-            )
+            recipient = User.objects.get(pk=attrs['recipient_id'], is_active=True)
         except User.DoesNotExist:
-            raise serializers.ValidationError(
-                {'institution_id': 'Institution not found or not verified.'}
-            )
+            raise serializers.ValidationError({'recipient_id': 'User not found.'})
 
-        # Validate user_book belongs to donor and is available
+        if recipient == donor:
+            raise serializers.ValidationError({'recipient_id': 'You cannot gift a book to yourself.'})
+
+        if recipient.is_institutional:
+            if not recipient.is_verified:
+                raise serializers.ValidationError(
+                    {'recipient_id': 'Institution not found or not verified.'}
+                )
+        else:
+            # For individuals, the book must be on their active wishlist
+            try:
+                user_book_for_check = UserBook.objects.get(pk=attrs['user_book_id'])
+            except UserBook.DoesNotExist:
+                raise serializers.ValidationError({'user_book_id': 'Book not available.'})
+            if not WishlistItem.objects.filter(
+                user=recipient,
+                book=user_book_for_check.book,
+                is_active=True,
+            ).exists():
+                raise serializers.ValidationError(
+                    {'recipient_id': 'This book is not on that user\'s wishlist.'}
+                )
+
         try:
             user_book = UserBook.objects.get(
                 pk=attrs['user_book_id'],
@@ -87,7 +100,7 @@ class DonationCreateSerializer(serializers.Serializer):
         except UserBook.DoesNotExist:
             raise serializers.ValidationError({'user_book_id': 'Book not available.'})
 
-        attrs['institution'] = institution
+        attrs['recipient'] = recipient
         attrs['user_book'] = user_book
         attrs['donor'] = donor
         return attrs
@@ -95,7 +108,7 @@ class DonationCreateSerializer(serializers.Serializer):
     def create(self, validated_data):
         return Donation.objects.create(
             donor=validated_data['donor'],
-            institution=validated_data['institution'],
+            recipient=validated_data['recipient'],
             user_book=validated_data['user_book'],
             message=validated_data.get('message', ''),
         )

--- a/apps/donations/serializers.py
+++ b/apps/donations/serializers.py
@@ -51,6 +51,9 @@ class DonationSerializer(serializers.ModelSerializer):
         return None
 
 
+_CONDITION_RANK = {'like_new': 4, 'very_good': 3, 'good': 2, 'acceptable': 1}
+
+
 class DonationCreateSerializer(serializers.Serializer):
     recipient_id = serializers.UUIDField()
     user_book_id = serializers.UUIDField()
@@ -82,13 +85,18 @@ class DonationCreateSerializer(serializers.Serializer):
                 user_book_for_check = UserBook.objects.get(pk=attrs['user_book_id'])
             except UserBook.DoesNotExist:
                 raise serializers.ValidationError({'user_book_id': 'Book not available.'})
-            if not WishlistItem.objects.filter(
+            wishlist_item = WishlistItem.objects.filter(
                 user=recipient,
                 book=user_book_for_check.book,
                 is_active=True,
-            ).exists():
+            ).first()
+            if not wishlist_item:
                 raise serializers.ValidationError(
-                    {'recipient_id': 'This book is not on that user\'s wishlist.'}
+                    {'recipient_id': "This book is not on that user's wishlist."}
+                )
+            if _CONDITION_RANK.get(user_book_for_check.condition, 0) < _CONDITION_RANK.get(wishlist_item.min_condition, 0):
+                raise serializers.ValidationError(
+                    {'user_book_id': "Your book's condition does not meet the recipient's minimum preference."}
                 )
 
         try:

--- a/apps/donations/tests/test_donation_views.py
+++ b/apps/donations/tests/test_donation_views.py
@@ -14,7 +14,7 @@ class TestDonationViews:
         user = UserFactory()
         api_client.force_authenticate(user=user)
         DonationFactory(donor=user)
-        
+
         url = reverse('donation-list-create')
         response = api_client.get(url)
         assert response.status_code == status.HTTP_200_OK
@@ -25,26 +25,25 @@ class TestDonationViews:
         inst = UserFactory(account_type=User.AccountType.BOOKSTORE, is_verified=True)
         ub = UserBookFactory(user=donor, status=UserBook.Status.AVAILABLE)
         api_client.force_authenticate(user=donor)
-        
+
         url = reverse('donation-list-create')
         data = {
-            "institution_id": str(inst.id),
+            "recipient_id": str(inst.id),
             "user_book_id": str(ub.id),
             "message": "Enjoy!"
         }
         response = api_client.post(url, data, format='json')
         assert response.status_code == status.HTTP_201_CREATED
-        assert Donation.objects.filter(donor=donor, institution=inst).exists()
+        assert Donation.objects.filter(donor=donor, recipient=inst).exists()
 
     def test_donation_accept_success(self, api_client):
         inst = UserFactory(account_type=User.AccountType.LIBRARY, is_verified=True)
         api_client.force_authenticate(user=inst)
-        
-        donation = DonationFactory(institution=inst, status=Donation.Status.OFFERED)
-        
+
+        donation = DonationFactory(recipient=inst, status=Donation.Status.OFFERED)
+
         url = reverse('donation-accept', kwargs={'pk': donation.pk})
-        
-        # Patching correctly where it's called
+
         with patch("apps.donations.views.user_has_verified_shipping_address", return_value=True, create=True):
             response = api_client.post(url)
             assert response.status_code == status.HTTP_200_OK
@@ -54,14 +53,14 @@ class TestDonationViews:
     def test_donation_decline(self, api_client):
         inst = UserFactory(account_type=User.AccountType.LIBRARY)
         api_client.force_authenticate(user=inst)
-        
-        donation = DonationFactory(institution=inst, status=Donation.Status.OFFERED)
+
+        donation = DonationFactory(recipient=inst, status=Donation.Status.OFFERED)
         ub = donation.user_book
-        
+
         url = reverse('donation-decline', kwargs={'pk': donation.pk})
         response = api_client.post(url)
         assert response.status_code == status.HTTP_200_OK
-        
+
         donation.refresh_from_db()
         assert donation.status == Donation.Status.CANCELLED
         ub.refresh_from_db()

--- a/apps/donations/tests/test_donations_api.py
+++ b/apps/donations/tests/test_donations_api.py
@@ -44,7 +44,7 @@ def _make_institution():
 def _offer_donation(client, user_book, institution):
     return client.post(
         reverse("donation-list-create"),
-        {"institution_id": str(institution.id), "user_book_id": str(user_book.id)},
+        {"recipient_id": str(institution.id), "user_book_id": str(user_book.id)},
         format="json",
     )
 
@@ -71,9 +71,9 @@ class TestDonationOffer:
         assert resp.data["status"] == "offered"
         assert resp.data["donor"]["id"] == str(donor.id)
 
-    def test_offer_to_non_institution_rejected(self, api_client):
+    def test_offer_to_individual_without_wishlist_rejected(self, api_client):
         donor = UserFactory()
-        regular_user = UserFactory()  # account_type='individual'
+        regular_user = UserFactory()  # account_type='individual', book not on wishlist
         user_book = UserBookFactory(user=donor, book=BookFactory())
 
         client = _auth(api_client, donor)
@@ -206,11 +206,11 @@ class TestDonationAccept:
         client_inst = _auth(api_client, institution)
         client_inst.post(reverse("donation-accept", kwargs={"pk": donation_id}))
 
-        # Donor should now see institution address
+        # Donor should now see recipient address
         client_donor = _auth(api_client, donor)
         detail = client_donor.get(reverse("donation-list-create"))
         donation = next(d for d in detail.data if d["id"] == donation_id)
-        assert donation["institution_address"] is not None
+        assert donation["recipient_address"] is not None
 
 
 # ---------------------------------------------------------------------------
@@ -338,7 +338,7 @@ class TestDonationNotificationExceptions:
         # The donation itself was created even though the notification failed
         from apps.donations.models import Donation
 
-        assert Donation.objects.filter(donor=donor, institution=institution).exists()
+        assert Donation.objects.filter(donor=donor, recipient=institution).exists()
 
     def test_accept_notification_exception_still_returns_200(self, api_client):
         """Lines 117-118: exception in notification for donation acceptance."""
@@ -416,7 +416,7 @@ def _setup_accepted_donation(api_client):
 
     offer_resp = client_donor.post(
         reverse("donation-list-create"),
-        {"institution_id": str(institution.id), "user_book_id": str(user_book.id)},
+        {"recipient_id": str(institution.id), "user_book_id": str(user_book.id)},
         format="json",
     )
     donation_id = offer_resp.data["id"]

--- a/apps/donations/tests/test_serializers.py
+++ b/apps/donations/tests/test_serializers.py
@@ -3,9 +3,9 @@ from unittest.mock import MagicMock
 
 from apps.donations.serializers import DonationSerializer, DonationCreateSerializer
 from apps.donations.models import Donation
-from apps.inventory.models import UserBook
+from apps.inventory.models import UserBook, ConditionChoices, WishlistItem
 from apps.accounts.models import User
-from apps.tests.factories import UserFactory, UserBookFactory, DonationFactory
+from apps.tests.factories import UserFactory, UserBookFactory, DonationFactory, WishlistItemFactory
 
 @pytest.mark.django_db
 class TestDonationSerializers:
@@ -58,3 +58,23 @@ class TestDonationSerializers:
         serializer = DonationCreateSerializer(data=data, context={'request': request})
         assert not serializer.is_valid()
         assert 'user_book_id' in serializer.errors
+
+    def test_donation_create_condition_validation_for_individual(self):
+        donor = UserFactory()
+        recipient = UserFactory()
+        ub = UserBookFactory(user=donor, status=UserBook.Status.AVAILABLE, condition=ConditionChoices.ACCEPTABLE)
+
+        request = MagicMock(user=donor)
+
+        # Recipient wants like_new — donor's acceptable copy should be rejected
+        wishlist = WishlistItemFactory(user=recipient, book=ub.book, min_condition=ConditionChoices.LIKE_NEW)
+        data = {"recipient_id": str(recipient.id), "user_book_id": str(ub.id)}
+        serializer = DonationCreateSerializer(data=data, context={'request': request})
+        assert not serializer.is_valid()
+        assert 'user_book_id' in serializer.errors
+
+        # Recipient lowers minimum to acceptable — same book should now be valid
+        wishlist.min_condition = ConditionChoices.ACCEPTABLE
+        wishlist.save()
+        serializer = DonationCreateSerializer(data=data, context={'request': request})
+        assert serializer.is_valid(), serializer.errors

--- a/apps/donations/tests/test_serializers.py
+++ b/apps/donations/tests/test_serializers.py
@@ -1,5 +1,6 @@
 import pytest
-from rest_framework import serializers
+from unittest.mock import MagicMock
+
 from apps.donations.serializers import DonationSerializer, DonationCreateSerializer
 from apps.donations.models import Donation
 from apps.inventory.models import UserBook
@@ -11,23 +12,23 @@ class TestDonationSerializers:
     def test_donation_serializer_reveal_address(self):
         donor = UserFactory(username="donor")
         inst = UserFactory(
-            username="library", 
+            username="library",
             institution_name="Main Lib",
             address_line_1="123 Lib St",
             account_type=User.AccountType.LIBRARY
         )
-        donation = DonationFactory(donor=donor, institution=inst, status=Donation.Status.ACCEPTED)
-        
+        donation = DonationFactory(donor=donor, recipient=inst, status=Donation.Status.ACCEPTED)
+
         # 1. As donor -> should see address
         request = MagicMock(user=donor)
         serializer = DonationSerializer(instance=donation, context={'request': request})
-        assert serializer.data['institution_address']['address_line_1'] == "123 Lib St"
+        assert serializer.data['recipient_address']['address_line_1'] == "123 Lib St"
         assert serializer.data['is_recipient'] is False
 
-        # 2. As institution -> should not see their own address in this field but is_recipient is True
+        # 2. As recipient -> should not see their own address in this field but is_recipient is True
         request_inst = MagicMock(user=inst)
         serializer_inst = DonationSerializer(instance=donation, context={'request': request_inst})
-        assert serializer_inst.data['institution_address'] is None
+        assert serializer_inst.data['recipient_address'] is None
         assert serializer_inst.data['is_recipient'] is True
 
     def test_donation_create_serializer_validation(self):
@@ -35,27 +36,25 @@ class TestDonationSerializers:
         # Invalid institution (not verified)
         inst_unverified = UserFactory(account_type=User.AccountType.LIBRARY, is_verified=False)
         ub = UserBookFactory(user=donor, status=UserBook.Status.AVAILABLE)
-        
+
         request = MagicMock(user=donor)
         data = {
-            "institution_id": str(inst_unverified.id),
+            "recipient_id": str(inst_unverified.id),
             "user_book_id": str(ub.id)
         }
         serializer = DonationCreateSerializer(data=data, context={'request': request})
         assert not serializer.is_valid()
-        assert 'institution_id' in serializer.errors
+        assert 'recipient_id' in serializer.errors
 
         # Valid institution
         inst_verified = UserFactory(account_type=User.AccountType.LIBRARY, is_verified=True)
-        data['institution_id'] = str(inst_verified.id)
+        data['recipient_id'] = str(inst_verified.id)
         serializer = DonationCreateSerializer(data=data, context={'request': request})
         assert serializer.is_valid()
-        
+
         # Invalid book (not available)
         ub.status = UserBook.Status.RESERVED
         ub.save()
         serializer = DonationCreateSerializer(data=data, context={'request': request})
         assert not serializer.is_valid()
         assert 'user_book_id' in serializer.errors
-
-from unittest.mock import MagicMock

--- a/apps/donations/views.py
+++ b/apps/donations/views.py
@@ -2,7 +2,6 @@ import logging
 
 from django.db import transaction
 from django.http import Http404
-from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from rest_framework import permissions, status
 from rest_framework.response import Response
@@ -23,8 +22,8 @@ logger = logging.getLogger(__name__)
 
 class DonationListCreateView(APIView):
     """
-    GET  /api/v1/donations/ — user's donations as donor or institution.
-    POST /api/v1/donations/ — offer a donation.
+    GET  /api/v1/donations/ — user's donations as donor or recipient.
+    POST /api/v1/donations/ — offer a donation/gift.
     """
 
     permission_classes = [permissions.IsAuthenticated]
@@ -38,13 +37,20 @@ class DonationListCreateView(APIView):
         from django.db.models import Q
 
         user = request.user
-        donations = (
-            Donation.objects.filter(Q(donor=user) | Q(institution=user))
-            .select_related("donor", "institution", "user_book__book")
-            .order_by("-created_at")
-        )
+        direction = request.query_params.get("direction", "")
+
+        qs = Donation.objects.select_related("donor", "recipient", "user_book__book")
+
+        if direction == "offered":
+            qs = qs.filter(donor=user)
+        elif direction == "received":
+            qs = qs.filter(recipient=user)
+        else:
+            qs = qs.filter(Q(donor=user) | Q(recipient=user))
+
+        qs = qs.order_by("-created_at")
         return Response(
-            DonationSerializer(donations, many=True, context={"request": request}).data
+            DonationSerializer(qs, many=True, context={"request": request}).data
         )
 
     def post(self, request):
@@ -54,20 +60,24 @@ class DonationListCreateView(APIView):
         serializer.is_valid(raise_exception=True)
         donation = serializer.save()
 
-        # Notify institution
+        recipient = donation.recipient
+        is_institutional = recipient.is_institutional
+        verb = "donate" if is_institutional else "gift"
+        display_name = getattr(recipient, 'institution_name', None) or recipient.username
+
         try:
             from apps.notifications.models import Notification
 
             Notification.objects.create(
-                user=donation.institution,
+                user=recipient,
                 notification_type="donation_offered",
-                title="Donation offer received",
-                body=f"{donation.donor.username} would like to donate {donation.user_book.book.title}.",
+                title="Gift offer received" if not is_institutional else "Donation offer received",
+                body=f"{donation.donor.username} would like to {verb} {donation.user_book.book.title} to you.",
                 metadata={"donation_id": str(donation.pk)},
             )
         except Exception:
             logger.exception(
-                "Failed to notify institution of donation offer %s", donation.pk
+                "Failed to notify recipient of donation offer %s", donation.pk
             )
 
         return Response(
@@ -77,22 +87,20 @@ class DonationListCreateView(APIView):
 
 
 class DonationAcceptView(APIView):
-    """POST /api/v1/donations/:id/accept/ — institution accepts a donation."""
+    """POST /api/v1/donations/:id/accept/ — recipient accepts a donation/gift."""
 
     permission_classes = [permissions.IsAuthenticated, EmailVerifiedPermission]
 
     def post(self, request, pk):
         with transaction.atomic():
-            # Lock the donation row for update
             donation = (
                 Donation.objects.select_for_update()
-                .filter(pk=pk, institution=request.user, status=Donation.Status.OFFERED)
+                .filter(pk=pk, recipient=request.user, status=Donation.Status.OFFERED)
                 .first()
             )
             if not donation:
                 raise Http404
 
-            # Lock the user_book row for update
             from apps.inventory.models import UserBook
 
             user_book = (
@@ -106,11 +114,9 @@ class DonationAcceptView(APIView):
             donation.status = Donation.Status.ACCEPTED
             donation.save(update_fields=["status"])
 
-            # Reserve the book
             user_book.status = UserBook.Status.RESERVED
             user_book.save(update_fields=["status"])
 
-            # Create a Trade record — must succeed for the accept to be valid
             from apps.trading.models import Trade, TradeShipment
 
             trade = Trade.objects.create(
@@ -121,21 +127,25 @@ class DonationAcceptView(APIView):
             TradeShipment.objects.create(
                 trade=trade,
                 sender=donation.donor,
-                receiver=donation.institution,
+                receiver=donation.recipient,
                 user_book=donation.user_book,
             )
 
-            # Notify donor
+            recipient = donation.recipient
+            is_institutional = recipient.is_institutional
+            display_name = getattr(recipient, 'institution_name', None) or recipient.username
+            noun = "donation" if is_institutional else "gift"
+
             try:
                 from apps.notifications.models import Notification
 
                 Notification.objects.create(
                     user=donation.donor,
                     notification_type="donation_accepted",
-                    title="Donation accepted!",
+                    title=f"{noun.capitalize()} accepted!",
                     body=(
-                        f"{donation.institution.institution_name or donation.institution.username} "
-                        f"has accepted your donation of {donation.user_book.book.title}. "
+                        f"{display_name} has accepted your {noun} of "
+                        f"{donation.user_book.book.title}. "
                         f"Shipping address is now available."
                     ),
                     metadata={"donation_id": str(donation.pk)},
@@ -149,7 +159,7 @@ class DonationAcceptView(APIView):
 
 
 class DonationDeclineView(APIView):
-    """POST /api/v1/donations/:id/decline/ — institution declines a donation."""
+    """POST /api/v1/donations/:id/decline/ — recipient declines a donation/gift."""
 
     permission_classes = [permissions.IsAuthenticated]
 
@@ -157,7 +167,7 @@ class DonationDeclineView(APIView):
         with transaction.atomic():
             donation = (
                 Donation.objects.select_for_update()
-                .filter(pk=pk, institution=request.user, status=Donation.Status.OFFERED)
+                .filter(pk=pk, recipient=request.user, status=Donation.Status.OFFERED)
                 .first()
             )
             if not donation:
@@ -166,18 +176,19 @@ class DonationDeclineView(APIView):
             donation.status = Donation.Status.CANCELLED
             donation.save(update_fields=["status"])
 
-        # Notify donor
+        recipient = donation.recipient
+        is_institutional = recipient.is_institutional
+        display_name = getattr(recipient, 'institution_name', None) or recipient.username
+        noun = "donation" if is_institutional else "gift"
+
         try:
             from apps.notifications.models import Notification
 
             Notification.objects.create(
                 user=donation.donor,
                 notification_type="donation_declined",
-                title="Donation declined",
-                body=(
-                    f"{donation.institution.institution_name or donation.institution.username} "
-                    f"has declined your donation offer."
-                ),
+                title=f"{noun.capitalize()} declined",
+                body=f"{display_name} has declined your {noun} offer.",
                 metadata={"donation_id": str(donation.pk)},
             )
         except Exception:
@@ -185,4 +196,4 @@ class DonationDeclineView(APIView):
                 "Failed to notify donor of donation decline %s", donation.pk
             )
 
-        return Response({"detail": "Donation offer declined."})
+        return Response({"detail": "Offer declined."})

--- a/apps/inventory/book_urls.py
+++ b/apps/inventory/book_urls.py
@@ -5,4 +5,5 @@ from . import views
 urlpatterns = [
     path('', views.MyBooksView.as_view(), name='my-books-list'),
     path('<uuid:pk>/', views.MyBookDetailView.as_view(), name='my-book-detail'),
+    path('<uuid:pk>/wanted-by/', views.BookWantedByView.as_view(), name='my-book-wanted-by'),
 ]

--- a/apps/inventory/serializers.py
+++ b/apps/inventory/serializers.py
@@ -65,6 +65,8 @@ class UserBookSerializer(serializers.ModelSerializer):
     book = BookSerializer(read_only=True)
     user_id = serializers.UUIDField(read_only=True, source="user.id")
     username = serializers.CharField(read_only=True, source="user.username")
+    want_count = serializers.SerializerMethodField()
+    is_institution_wanted = serializers.SerializerMethodField()
 
     class Meta:
         model = UserBook
@@ -76,6 +78,8 @@ class UserBookSerializer(serializers.ModelSerializer):
             "condition",
             "condition_notes",
             "status",
+            "want_count",
+            "is_institution_wanted",
             "created_at",
             "updated_at",
         ]
@@ -84,9 +88,17 @@ class UserBookSerializer(serializers.ModelSerializer):
             "user_id",
             "username",
             "book",
+            "want_count",
+            "is_institution_wanted",
             "created_at",
             "updated_at",
         ]
+
+    def get_want_count(self, obj):
+        return getattr(obj, 'want_count', 0) or 0
+
+    def get_is_institution_wanted(self, obj):
+        return bool(getattr(obj, 'is_institution_wanted', False))
 
 
 class UserBookCreateSerializer(serializers.Serializer):
@@ -142,6 +154,8 @@ class UserBookUpdateSerializer(serializers.ModelSerializer):
 class WishlistItemSerializer(serializers.ModelSerializer):
     book = BookSerializer(read_only=True)
     user_id = serializers.UUIDField(read_only=True, source="user.id")
+    viewer_can_gift = serializers.SerializerMethodField()
+    viewer_user_book_id = serializers.SerializerMethodField()
 
     class Meta:
         model = WishlistItem
@@ -155,10 +169,21 @@ class WishlistItemSerializer(serializers.ModelSerializer):
             "exclude_abridged",
             "format_preferences",
             "is_active",
+            "viewer_can_gift",
+            "viewer_user_book_id",
             "created_at",
             "updated_at",
         ]
-        read_only_fields = ["id", "user_id", "book", "created_at", "updated_at"]
+        read_only_fields = ["id", "user_id", "book", "viewer_can_gift", "viewer_user_book_id", "created_at", "updated_at"]
+
+    def get_viewer_can_gift(self, obj):
+        viewer_book_id_map = self.context.get('viewer_book_id_map', {})
+        return obj.book_id in viewer_book_id_map
+
+    def get_viewer_user_book_id(self, obj):
+        viewer_book_id_map = self.context.get('viewer_book_id_map', {})
+        val = viewer_book_id_map.get(obj.book_id)
+        return str(val) if val else None
 
 
 class WishlistItemCreateSerializer(serializers.Serializer):

--- a/apps/inventory/views.py
+++ b/apps/inventory/views.py
@@ -120,17 +120,49 @@ class MyBooksView(APIView):
     permission_classes = [EmailVerifiedPermission]
 
     def get(self, request):
+        from django.db.models import Count, Exists, OuterRef, Q
+
         queryset = (
             UserBook.objects.filter(user=request.user)
             .select_related("book")
             .exclude(status=UserBook.Status.REMOVED)
+            .annotate(
+                want_count=Count(
+                    'book__wishlist_entries',
+                    filter=Q(
+                        book__wishlist_entries__is_active=True,
+                        book__wishlist_entries__user__is_active=True,
+                    ) & ~Q(book__wishlist_entries__user=request.user),
+                    distinct=True,
+                ),
+                is_institution_wanted=Exists(
+                    WishlistItem.objects.filter(
+                        book=OuterRef('book'),
+                        is_active=True,
+                        user__is_active=True,
+                        user__account_type__in=[
+                            User.AccountType.LIBRARY,
+                            User.AccountType.BOOKSTORE,
+                        ],
+                        user__is_verified=True,
+                    )
+                ),
+            )
         )
+
+        filter_by = request.query_params.get("filter_by", "")
+        if filter_by == "wanted":
+            queryset = queryset.filter(Q(want_count__gt=0) | Q(is_institution_wanted=True))
 
         sort_by = request.query_params.get("sort_by", "created_at")
         sort_order = request.query_params.get("sort_order", "desc")
-        queryset = apply_book_sorting(queryset, sort_by, sort_order)
 
-        # Apply pagination
+        if sort_by == "demand":
+            ordering = "-want_count" if sort_order == "desc" else "want_count"
+            queryset = queryset.order_by(ordering)
+        else:
+            queryset = apply_book_sorting(queryset, sort_by, sort_order)
+
         paginator = PageNumberPagination()
         paginated = paginator.paginate_queryset(queryset, request)
         serializer = UserBookSerializer(paginated, many=True)
@@ -197,6 +229,42 @@ class MyBookDetailView(APIView):
         obj.status = UserBook.Status.REMOVED
         obj.save(update_fields=["status"])
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class BookWantedByView(APIView):
+    """
+    GET /api/v1/my-books/:pk/wanted-by/
+    Returns individuals and institutions who have the given UserBook's book
+    on their wishlist, so the owner can choose a gift recipient.
+    """
+
+    permission_classes = [EmailVerifiedPermission]
+
+    def get(self, request, pk):
+        from apps.accounts.serializers import UserPublicProfileSerializer
+
+        user_book = get_object_or_404(UserBook, pk=pk, user=request.user, status=UserBook.Status.AVAILABLE)
+
+        wishlist_entries = (
+            WishlistItem.objects.filter(
+                book=user_book.book,
+                is_active=True,
+                user__is_active=True,
+            )
+            .exclude(user=request.user)
+            .select_related("user")
+            .order_by("created_at")
+        )
+
+        results = []
+        for item in wishlist_entries:
+            results.append({
+                "user": UserPublicProfileSerializer(item.user).data,
+                "wishlist_item_id": str(item.pk),
+                "min_condition": item.min_condition,
+            })
+
+        return Response(results)
 
 
 class WishlistView(APIView):

--- a/apps/tests/factories.py
+++ b/apps/tests/factories.py
@@ -154,7 +154,7 @@ class DonationFactory(factory.django.DjangoModelFactory):
         model = Donation
 
     donor = factory.SubFactory(UserFactory)
-    institution = factory.SubFactory(UserFactory, account_type=User.AccountType.LIBRARY)
+    recipient = factory.SubFactory(UserFactory, account_type=User.AccountType.LIBRARY)
     user_book = factory.SubFactory(UserBookFactory)
     status = Donation.Status.OFFERED
 

--- a/frontend/src/components/common/GiftModal.jsx
+++ b/frontend/src/components/common/GiftModal.jsx
@@ -1,0 +1,217 @@
+import React, { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { myBooks as myBooksApi, donations as donationsApi } from '../../services/api.js';
+import LoadingSpinner from './LoadingSpinner.jsx';
+import ConditionBadge from './ConditionBadge.jsx';
+
+const CONDITION_RANK = { like_new: 4, very_good: 3, good: 2, acceptable: 1 };
+
+function conditionMeetsMin(condition, minCondition) {
+  return (CONDITION_RANK[condition] ?? 0) >= (CONDITION_RANK[minCondition] ?? 0);
+}
+
+/**
+ * Two modes:
+ *
+ * "Choose recipient" — triggered from My Books.
+ *   Required props: userBook (the UserBook being gifted)
+ *   Fetches /my-books/:id/wanted-by/ and shows a list of potential recipients.
+ *
+ * "Confirm gift" — triggered from a profile's wishlist.
+ *   Required props: recipientId, recipientUsername, userBookId, book
+ *   Shows a simple confirmation before submitting.
+ */
+export default function GiftModal({ open, onClose, onSuccess, userBook, recipientId, recipientUsername, userBookId, book }) {
+  const queryClient = useQueryClient();
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState(null);
+
+  const isChooseRecipientMode = !!userBook && !recipientId;
+  const isConfirmMode = !!recipientId && !!userBookId;
+
+  const { data: wantedBy, isLoading: wantedByLoading } = useQuery({
+    queryKey: ['wantedBy', userBook?.id],
+    queryFn: () => myBooksApi.wantedBy(userBook.id).then((r) => r.data),
+    enabled: open && isChooseRecipientMode,
+  });
+
+  const offerMutation = useMutation({
+    mutationFn: ({ recipientId: rid, ubId }) =>
+      donationsApi.offer({ recipient_id: rid, user_book_id: ubId, message }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['myBooks'] });
+      queryClient.invalidateQueries({ queryKey: ['donations'] });
+      setError(null);
+      setMessage('');
+      onSuccess?.();
+      onClose();
+    },
+    onError: (err) => {
+      const data = err?.response?.data;
+      const msg =
+        data?.non_field_errors?.[0] ||
+        data?.recipient_id?.[0] ||
+        data?.user_book_id?.[0] ||
+        data?.detail ||
+        'Failed to send gift offer.';
+      setError(msg);
+    },
+  });
+
+  if (!open) return null;
+
+  const displayBook = userBook?.book ?? book;
+
+  function handleBackdropClick(e) {
+    if (e.target === e.currentTarget) onClose();
+  }
+
+  function handleConfirm(rid, ubId) {
+    setError(null);
+    offerMutation.mutate({ recipientId: rid, ubId });
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(17,24,39,0.5)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        zIndex: 60, padding: '1rem',
+      }}
+      onMouseDown={handleBackdropClick}
+    >
+      <div className="card" style={{ width: 'min(520px, 100%)', padding: '1.5rem' }} role="dialog" aria-modal="true">
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '1rem' }}>
+          <h3 style={{ margin: 0 }}>Gift a Book</h3>
+          <button
+            className="btn btn-secondary btn-sm"
+            onClick={onClose}
+            style={{ padding: '0.25rem 0.5rem' }}
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        {displayBook && (
+          <div style={{ display: 'flex', gap: '0.75rem', marginBottom: '1rem', padding: '0.75rem', background: 'var(--color-bg-subtle, #f9fafb)', borderRadius: '0.5rem' }}>
+            {displayBook.cover_image_url && (
+              <img src={displayBook.cover_image_url} alt={displayBook.title} style={{ width: 48, height: 68, objectFit: 'cover', flexShrink: 0 }} />
+            )}
+            <div>
+              <p style={{ margin: '0 0 0.25rem', fontWeight: 600 }}>{displayBook.title}</p>
+              {displayBook.authors && (
+                <p style={{ margin: 0, fontSize: '0.875rem', color: 'var(--color-text-muted, #6b7280)' }}>
+                  {Array.isArray(displayBook.authors) ? displayBook.authors[0] : displayBook.authors}
+                </p>
+              )}
+              {userBook?.condition && <ConditionBadge condition={userBook.condition} />}
+            </div>
+          </div>
+        )}
+
+        {error && <div className="alert alert-error" style={{ marginBottom: '1rem' }}>{error}</div>}
+
+        {isChooseRecipientMode && (
+          <>
+            <p style={{ margin: '0 0 0.75rem', fontSize: '0.875rem', color: 'var(--color-text-muted, #6b7280)' }}>
+              Choose who to gift this book to. They won't owe you anything in return.
+            </p>
+
+            {wantedByLoading ? (
+              <LoadingSpinner center />
+            ) : !wantedBy?.length ? (
+              <p style={{ textAlign: 'center', color: 'var(--color-text-muted, #6b7280)', padding: '1rem 0' }}>
+                No one has this book on their wishlist right now.
+              </p>
+            ) : (
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxHeight: '280px', overflowY: 'auto' }}>
+                {wantedBy.map((entry) => {
+                  const eligible = conditionMeetsMin(userBook.condition, entry.min_condition);
+                  return (
+                    <div
+                      key={entry.wishlist_item_id}
+                      style={{
+                        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                        padding: '0.625rem 0.75rem', border: '1px solid var(--color-border, #e5e7eb)',
+                        borderRadius: '0.5rem',
+                        opacity: eligible ? 1 : 0.5,
+                      }}
+                    >
+                      <div>
+                        <span style={{ fontWeight: 500 }}>@{entry.user.username}</span>
+                        {entry.user.account_type !== 'individual' && (
+                          <span className="badge badge-blue" style={{ marginLeft: '0.5rem' }}>Institution</span>
+                        )}
+                        <div style={{ fontSize: '0.8125rem', color: 'var(--color-text-muted, #6b7280)', marginTop: '0.125rem' }}>
+                          Wants min: <ConditionBadge condition={entry.min_condition} />
+                        </div>
+                      </div>
+                      <button
+                        className="btn btn-primary btn-sm"
+                        disabled={!eligible || offerMutation.isPending}
+                        onClick={() => handleConfirm(entry.user.id, userBook.id)}
+                        title={eligible ? undefined : `Your copy doesn't meet their minimum condition (${entry.min_condition})`}
+                      >
+                        Gift
+                      </button>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            <div className="form-group" style={{ marginTop: '1rem' }}>
+              <label className="form-label" htmlFor="giftMessage">Message (optional)</label>
+              <textarea
+                id="giftMessage"
+                className="form-input"
+                rows={2}
+                maxLength={1000}
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder="Add a personal note..."
+                style={{ resize: 'vertical' }}
+              />
+            </div>
+          </>
+        )}
+
+        {isConfirmMode && (
+          <>
+            <p style={{ margin: '0 0 1rem', fontSize: '0.9375rem' }}>
+              Gift this book to <strong>@{recipientUsername}</strong>? They won't owe you anything in return.
+            </p>
+
+            <div className="form-group">
+              <label className="form-label" htmlFor="giftMessageConfirm">Message (optional)</label>
+              <textarea
+                id="giftMessageConfirm"
+                className="form-input"
+                rows={2}
+                maxLength={1000}
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                placeholder="Add a personal note..."
+                style={{ resize: 'vertical' }}
+              />
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end', marginTop: '0.75rem' }}>
+              <button className="btn btn-secondary" onClick={onClose} disabled={offerMutation.isPending}>
+                Cancel
+              </button>
+              <button
+                className="btn btn-primary"
+                onClick={() => handleConfirm(recipientId, userBookId)}
+                disabled={offerMutation.isPending}
+              >
+                {offerMutation.isPending ? 'Sending...' : 'Send gift offer'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/Donations.jsx
+++ b/frontend/src/pages/Donations.jsx
@@ -65,9 +65,9 @@ export default function Donations() {
   return (
     <div>
       <div className="page-header">
-        <h1 className="page-title">Donations</h1>
+        <h1 className="page-title">Donations &amp; Gifts</h1>
         <p className="page-subtitle">
-          Institutions (libraries, bookstores) can receive book donations from individuals.
+          Books given to institutions (libraries, bookstores) or gifted to individuals — no trade required.
         </p>
       </div>
 
@@ -97,7 +97,7 @@ export default function Donations() {
         <div className={styles.empty}>
           <p className={styles.emptyTitle}>No donations found</p>
           <p className={styles.emptySubtitle}>
-            Browse institution profiles to see their wanted book lists and offer donations.
+            Browse someone's profile to gift them a book from their wishlist, or donate to a library or bookstore.
           </p>
         </div>
       ) : (
@@ -171,7 +171,7 @@ export default function Donations() {
                         onClick={() => acceptMutation.mutate(donation.id)}
                         disabled={acceptMutation.isPending}
                       >
-                        Accept Donation
+                        Accept
                       </button>
                       <button
                         className="btn btn-outline-danger btn-sm"

--- a/frontend/src/pages/Donations.jsx
+++ b/frontend/src/pages/Donations.jsx
@@ -108,7 +108,7 @@ export default function Donations() {
               const userBook = donation.user_book ?? donation.book;
               const book = userBook?.book ?? userBook;
               const donor = donation.donor ?? donation.from_user;
-              const recipient = donation.institution ?? donation.recipient ?? donation.to_user;
+              const recipient = donation.recipient ?? donation.to_user;
               const isPending = donation.status === 'offered';
               const isRecipient = donation.is_recipient ?? false;
 

--- a/frontend/src/pages/Donations.test.jsx
+++ b/frontend/src/pages/Donations.test.jsx
@@ -55,7 +55,7 @@ describe('Donations page', () => {
         expect(screen.getByAltText('The Bluest Eye')).toHaveAttribute('src', 'https://example.com/bluesteye.jpg');
         expect(screen.getByText('@central-library')).toBeInTheDocument();
 
-        await userEvent.click(screen.getByRole('button', { name: 'Accept Donation' }));
+        await userEvent.click(screen.getByRole('button', { name: 'Accept' }));
 
         await waitFor(() => {
             expect(donations.accept).toHaveBeenCalledWith('donation-1');
@@ -121,7 +121,7 @@ describe('Donations page', () => {
         });
         donations.accept.mockRejectedValue({ response: { data: { detail: 'Cannot accept this donation.' } } });
         renderWithProviders(<Donations />);
-        await userEvent.click(await screen.findByRole('button', { name: 'Accept Donation' }));
+        await userEvent.click(await screen.findByRole('button', { name: 'Accept' }));
         await waitFor(() => expect(screen.getByText('Cannot accept this donation.')).toBeInTheDocument());
     });
 
@@ -182,7 +182,7 @@ describe('Donations page', () => {
         });
         donations.accept.mockRejectedValueOnce({ response: { data: {} } });
         renderWithProviders(<Donations />);
-        await userEvent.click(await screen.findByRole('button', { name: 'Accept Donation' }));
+        await userEvent.click(await screen.findByRole('button', { name: 'Accept' }));
         await waitFor(() => expect(screen.getByText('Failed to accept.')).toBeInTheDocument());
     });
 

--- a/frontend/src/pages/Donations.test.jsx
+++ b/frontend/src/pages/Donations.test.jsx
@@ -32,7 +32,7 @@ describe('Donations page', () => {
                         created_at: '2026-04-20T12:00:00Z',
                         is_recipient: true,
                         donor: { id: 'user-1', username: 'bart0605' },
-                        institution: { id: 'inst-1', username: 'central-library' },
+                        recipient: { id: 'inst-1', username: 'central-library' },
                         user_book: {
                             condition: 'good',
                             book: {
@@ -91,7 +91,7 @@ describe('Donations page', () => {
                         created_at: '2026-04-20T12:00:00Z',
                         is_recipient: false,
                         donor: { id: 'user-1', username: 'alice' },
-                        institution: { id: 'inst-1', username: 'library' },
+                        recipient: { id: 'inst-1', username: 'library' },
                         user_book: null,
                         book: null,
                     },
@@ -113,7 +113,7 @@ describe('Donations page', () => {
                         created_at: '2026-04-20T12:00:00Z',
                         is_recipient: true,
                         donor: { id: 'user-1', username: 'alice' },
-                        institution: { id: 'inst-1', username: 'library' },
+                        recipient: { id: 'inst-1', username: 'library' },
                         user_book: { condition: 'good', book: { id: 'book-5', title: 'Error Book', authors: ['Author'] } },
                     },
                 ],
@@ -175,7 +175,7 @@ describe('Donations page', () => {
                     created_at: '2026-04-20T12:00:00Z',
                     is_recipient: true,
                     donor: { id: 'user-1', username: 'alice' },
-                    institution: { id: 'inst-1', username: 'library' },
+                    recipient: { id: 'inst-1', username: 'library' },
                     user_book: { condition: 'good', book: { id: 'book-5', title: 'Error Book', authors: [] } },
                 }],
             },
@@ -197,7 +197,7 @@ describe('Donations page', () => {
                         created_at: '2026-04-20T12:00:00Z',
                         is_recipient: false,
                         donor: { id: 'user-1', username: 'sender' },
-                        institution: { id: 'inst-1', username: 'lib' },
+                        recipient: { id: 'inst-1', username: 'lib' },
                         user_book: { condition: 'good', book: { id: 'book-a', title: 'Array Book', authors: ['Writer'] } },
                     },
                 ],
@@ -207,7 +207,7 @@ describe('Donations page', () => {
         expect(await screen.findByText('Array Book')).toBeInTheDocument();
     });
 
-    it('renders donation using to_user fallback when institution and recipient are absent', async () => {
+    it('renders donation using to_user fallback when recipient is absent', async () => {
         donations.list.mockResolvedValue({
             data: {
                 count: 1,
@@ -217,7 +217,7 @@ describe('Donations page', () => {
                     created_at: '2026-04-20T12:00:00Z',
                     is_recipient: false,
                     donor: { id: 'user-1', username: 'alice' },
-                    // No institution or recipient — falls back to to_user
+                    // No recipient — falls back to to_user
                     to_user: { id: 'inst-2', username: 'community-lib' },
                     user_book: { condition: 'good', book: { id: 'book-tou', title: 'To User Book', authors: [] } },
                 }],
@@ -239,7 +239,7 @@ describe('Donations page', () => {
                         created_at: '2026-04-20T12:00:00Z',
                         is_recipient: true,
                         donor: { id: 'user-1', username: 'bart0605' },
-                        institution: { id: 'inst-1', username: 'library' },
+                        recipient: { id: 'inst-1', username: 'library' },
                         user_book: {
                             condition: 'good',
                             book: { id: 'book-3', title: 'Test Book', authors: ['Author'] },
@@ -264,7 +264,7 @@ describe('Donations page', () => {
                     created_at: '2026-04-20T12:00:00Z',
                     is_recipient: true,
                     donor: { id: 'user-2', username: 'bob' },
-                    institution: { id: 'inst-1', username: 'library' },
+                    recipient: { id: 'inst-1', username: 'library' },
                     user_book: { condition: 'good', book: { id: 'bk1', title: 'Error Book', authors: [] } },
                 }],
             },

--- a/frontend/src/pages/MyBooks.jsx
+++ b/frontend/src/pages/MyBooks.jsx
@@ -8,6 +8,7 @@ import ISBNInput from '../components/common/ISBNInput.jsx';
 import Tooltip from '../components/common/Tooltip.jsx';
 import Pagination from '../components/common/Pagination.jsx';
 import AddressPromptModal from '../components/common/AddressPromptModal.jsx';
+import GiftModal from '../components/common/GiftModal.jsx';
 import { getBookCoverUrl, getBookPrimaryAuthor } from '../utils/book.js';
 import styles from './MyBooks.module.css';
 
@@ -47,11 +48,19 @@ export default function MyBooks() {
   const [editCondition, setEditCondition] = useState('');
   const [sortBy, setSortBy] = useState('created_at');
   const [sortOrder, setSortOrder] = useState('desc');
+  const [filterBy, setFilterBy] = useState('');
+  const [giftTarget, setGiftTarget] = useState(null);
   const [showAddressPrompt, setShowAddressPrompt] = useState(false);
 
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ['myBooks', page, sortBy, sortOrder],
-    queryFn: () => myBooksApi.list({ page, page_size: PAGE_SIZE, sort_by: sortBy, sort_order: sortOrder }).then((r) => r.data),
+    queryKey: ['myBooks', page, sortBy, sortOrder, filterBy],
+    queryFn: () => myBooksApi.list({
+      page,
+      page_size: PAGE_SIZE,
+      sort_by: sortBy,
+      sort_order: sortOrder,
+      ...(filterBy ? { filter_by: filterBy } : {}),
+    }).then((r) => r.data),
   });
 
   const addMutation = useMutation({
@@ -230,14 +239,12 @@ export default function MyBooks() {
               <select
                 className="form-input"
                 value={sortBy}
-                onChange={(e) => {
-                  setSortBy(e.target.value);
-                  setPage(1);
-                }}
+                onChange={(e) => { setSortBy(e.target.value); setPage(1); }}
               >
                 <option value="created_at">Date Added</option>
                 <option value="title">Title</option>
                 <option value="author">Author</option>
+                <option value="demand">Most Wanted</option>
               </select>
             </div>
             <div style={{ flex: 1, minWidth: '150px' }}>
@@ -245,14 +252,19 @@ export default function MyBooks() {
               <select
                 className="form-input"
                 value={sortOrder}
-                onChange={(e) => {
-                  setSortOrder(e.target.value);
-                  setPage(1);
-                }}
+                onChange={(e) => { setSortOrder(e.target.value); setPage(1); }}
               >
                 <option value="desc">Descending</option>
                 <option value="asc">Ascending</option>
               </select>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+              <button
+                className={`btn btn-sm ${filterBy === 'wanted' ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => { setFilterBy(filterBy === 'wanted' ? '' : 'wanted'); setPage(1); }}
+              >
+                {filterBy === 'wanted' ? '✓ Wanted only' : 'Wanted only'}
+              </button>
             </div>
           </div>
 
@@ -278,14 +290,12 @@ export default function MyBooks() {
               <select
                 className="form-input"
                 value={sortBy}
-                onChange={(e) => {
-                  setSortBy(e.target.value);
-                  setPage(1);
-                }}
+                onChange={(e) => { setSortBy(e.target.value); setPage(1); }}
               >
                 <option value="created_at">Date Added</option>
                 <option value="title">Title</option>
                 <option value="author">Author</option>
+                <option value="demand">Most Wanted</option>
               </select>
             </div>
             <div style={{ flex: 1, minWidth: '150px' }}>
@@ -293,14 +303,19 @@ export default function MyBooks() {
               <select
                 className="form-input"
                 value={sortOrder}
-                onChange={(e) => {
-                  setSortOrder(e.target.value);
-                  setPage(1);
-                }}
+                onChange={(e) => { setSortOrder(e.target.value); setPage(1); }}
               >
                 <option value="desc">Descending</option>
                 <option value="asc">Ascending</option>
               </select>
+            </div>
+            <div style={{ display: 'flex', alignItems: 'flex-end' }}>
+              <button
+                className={`btn btn-sm ${filterBy === 'wanted' ? 'btn-primary' : 'btn-secondary'}`}
+                onClick={() => { setFilterBy(filterBy === 'wanted' ? '' : 'wanted'); setPage(1); }}
+              >
+                {filterBy === 'wanted' ? '✓ Wanted only' : 'Wanted only'}
+              </button>
             </div>
           </div>
           <div className={styles.bookList}>
@@ -341,9 +356,31 @@ export default function MyBooks() {
                       ) : (
                         <span className={`badge ${statusConfig.cls}`}>{statusConfig.label}</span>
                       )}
+                      {item.want_count > 0 && (
+                        <Tooltip content="This many people have this book on their wishlist.">
+                          <span className="badge badge-blue" style={{ cursor: 'pointer' }} onClick={() => setGiftTarget(item)}>
+                            {item.want_count} want{item.want_count === 1 ? 's' : ''} this
+                          </span>
+                        </Tooltip>
+                      )}
+                      {item.is_institution_wanted && (
+                        <Tooltip content="At least one verified library or bookstore wants this book.">
+                          <span className="badge badge-amber" style={{ cursor: 'pointer' }} onClick={() => setGiftTarget(item)}>
+                            Wanted by institution
+                          </span>
+                        </Tooltip>
+                      )}
                     </div>
                   </div>
                   <div className={styles.bookActions}>
+                    {item.status === 'available' && (item.want_count > 0 || item.is_institution_wanted) && !isEditing && (
+                      <button
+                        className="btn btn-secondary btn-sm"
+                        onClick={() => setGiftTarget(item)}
+                      >
+                        Gift
+                      </button>
+                    )}
                     {isEditing ? (
                       <div className={styles.editForm}>
                         <select
@@ -424,6 +461,13 @@ export default function MyBooks() {
       )}
 
       <AddressPromptModal open={showAddressPrompt} onClose={() => setShowAddressPrompt(false)} />
+
+      <GiftModal
+        open={!!giftTarget}
+        onClose={() => setGiftTarget(null)}
+        onSuccess={() => queryClient.invalidateQueries({ queryKey: ['myBooks'] })}
+        userBook={giftTarget}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/PublicProfile.jsx
+++ b/frontend/src/pages/PublicProfile.jsx
@@ -6,6 +6,7 @@ import useAuth from '../hooks/useAuth.js';
 import LoadingSpinner from '../components/common/LoadingSpinner.jsx';
 import ErrorMessage from '../components/common/ErrorMessage.jsx';
 import ConditionBadge, { CONDITION_CONFIG } from '../components/common/ConditionBadge.jsx';
+import GiftModal from '../components/common/GiftModal.jsx';
 import Tooltip from '../components/common/Tooltip.jsx';
 import { format } from 'date-fns';
 import { getBookCoverUrl, getBookPrimaryAuthor } from '../utils/book.js';
@@ -76,6 +77,7 @@ export default function PublicProfile() {
   const [wishlistPreferences, setWishlistPreferences] = useState(DEFAULT_WISHLIST_PREFERENCES);
   const [wishlistPrefMessage, setWishlistPrefMessage] = useState(null);
   const [wishlistPrefError, setWishlistPrefError] = useState(null);
+  const [giftItem, setGiftItem] = useState(null);
 
   const { data: profile, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['publicProfile', id],
@@ -453,7 +455,7 @@ export default function PublicProfile() {
           <div className={`card ${styles.section}`} data-testid="wanted-books-section">
             <h2 className={styles.sectionTitle}>Wanted Books</h2>
             <p className={styles.sectionSubtitle}>
-              Books this user is looking to receive via trade.
+              Books this user is looking to receive via trade or gift.
             </p>
             {publicWantedBooks.length === 0 ? (
               <p className={styles.emptyText}>No wanted books listed.</p>
@@ -476,6 +478,15 @@ export default function PublicProfile() {
                           <span>
                             Min: <ConditionBadge condition={item.min_condition} />
                           </span>
+                        )}
+                        {!isOwnProfile && item.viewer_can_gift && (
+                          <button
+                            className="btn btn-secondary btn-sm"
+                            style={{ marginTop: '0.5rem' }}
+                            onClick={() => setGiftItem(item)}
+                          >
+                            Gift this
+                          </button>
                         )}
                       </div>
                     </div>
@@ -581,6 +592,17 @@ export default function PublicProfile() {
           </div>
         )}
       </div>
+
+      {giftItem && (
+        <GiftModal
+          open={!!giftItem}
+          onClose={() => setGiftItem(null)}
+          recipientId={id}
+          recipientUsername={profile?.username}
+          userBookId={giftItem.viewer_user_book_id}
+          book={giftItem.book ?? giftItem}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -159,6 +159,7 @@ export const myBooks = {
   add: (data) => apiClient.post('/my-books/', data),
   update: (id, data) => apiClient.patch(`/my-books/${id}/`, data),
   remove: (id) => apiClient.delete(`/my-books/${id}/`),
+  wantedBy: (bookId) => apiClient.get(`/my-books/${bookId}/wanted-by/`),
 };
 
 // ── Wishlist (Want-list) ──────────────────────────────────────────────────────
@@ -198,9 +199,10 @@ export const trades = {
   sendMessage: (id, data) => apiClient.post(`/trades/${id}/messages/`, data),
 };
 
-// ── Donations ─────────────────────────────────────────────────────────────────
+// ── Donations / Gifts ─────────────────────────────────────────────────────────
 export const donations = {
   list: (params) => apiClient.get('/donations/', { params }),
+  // data: { recipient_id, user_book_id, message? }
   offer: (data) => apiClient.post('/donations/', data),
   accept: (id) => apiClient.post(`/donations/${id}/accept/`),
   decline: (id) => apiClient.post(`/donations/${id}/decline/`),


### PR DESCRIPTION
## Summary

Extends the donations system to support peer-to-peer gifting between individual users, in addition to the existing institutional donation workflow. Individual users can now gift books directly to other individuals whose wishlist includes the book — no trade required.

## Key Changes

**Backend:**
- Renamed `Donation.institution` field to `Donation.recipient` to support both institutional and individual recipients
- Updated `DonationCreateSerializer` to validate individual recipients (must have book on active wishlist) vs. institutional recipients (must be verified)
- Added `BookWantedByView` endpoint (`GET /api/v1/my-books/:pk/wanted-by/`) to discover potential gift recipients for a specific book
- Enhanced `MyBooksView` to annotate `want_count` (number of active wishlist entries) and `is_institution_wanted` flag
- Added `filter_by=wanted` query parameter to filter books that someone wants
- Added `sort_by=demand` option to sort by wishlist demand
- Updated `DonationListCreateView` to support `direction` query parameter (`offered`/`received`) for filtering donations
- Updated notification logic to distinguish between gifts (individual→individual) and donations (individual→institution)
- Added migration to rename `institution` field to `recipient`

**Frontend:**
- Created new `GiftModal` component with two modes:
  - "Choose recipient" mode: triggered from My Books, fetches wanted-by list, shows eligible recipients filtered by condition requirements
  - "Confirm gift" mode: triggered from a profile's wishlist, shows simple confirmation before submitting
- Updated `MyBooks` page to add "Wanted only" filter button and "Most Wanted" sort option
- Updated `PublicProfile` page to integrate gift modal on wishlist items, showing "Gift" button for books the viewer owns
- Added `want_count` and `is_institution_wanted` fields to `UserBookSerializer`
- Added `viewer_can_gift` and `viewer_user_book_id` fields to `WishlistItemSerializer` to enable gift buttons on profiles
- Updated `PublicProfile` to populate `viewer_book_id_map` when rendering another user's wishlist

**Documentation:**
- Updated README with peer-to-peer gifting workflow and API examples
- Updated ARCHITECTURE.md to clarify donations app handles both institutional and individual gifting

## Implementation Details

- Condition validation: books must meet the recipient's minimum condition requirement to be giftable
- Wishlist requirement: individual recipients must have the book on their active wishlist; institutional recipients do not
- Self-gifting prevention: users cannot gift books to themselves
- Address reveal: recipient address is only revealed to donor after gift is accepted (consistent with trade workflow)
- Notifications: distinct messaging for gifts vs. donations based on recipient account type

https://claude.ai/code/session_01GfNjTQXpcBxnyXiVk8Xo2U