### PR TITLE
Karma scoring, percentile badges, and Community discovery page

### DIFF
--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -200,9 +200,11 @@ class User(AbstractBaseUser, PermissionsMixin):
             pass
         super().delete(*args, **kwargs)
 
+    GIFT_KARMA_MULTIPLIER = 2
+
     @property
     def karma(self) -> int:
-        return self.total_trades + self.gifts_given_count * 2
+        return self.total_trades + self.gifts_given_count * self.GIFT_KARMA_MULTIPLIER
 
     @property
     def max_active_matches(self):

--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -510,7 +510,7 @@ class CommunityListView(generics.ListAPIView):
             )
             .annotate(
                 karma_score=ExpressionWrapper(
-                    F("total_trades") + F("gifts_given_count") * 2,
+                    F("total_trades") + F("gifts_given_count") * User.GIFT_KARMA_MULTIPLIER,
                     output_field=IntegerField(),
                 ),
                 has_available_books=Exists(

--- a/apps/donations/tests/test_donation_views.py
+++ b/apps/donations/tests/test_donation_views.py
@@ -81,3 +81,15 @@ class TestDonationViews:
         assert donation.status == Donation.Status.CANCELLED
         ub.refresh_from_db()
         assert ub.status == UserBook.Status.AVAILABLE
+
+    def test_donation_decline_does_not_increment_gifts_given_count(self, api_client):
+        donor = UserFactory(gifts_given_count=0)
+        inst = UserFactory(account_type=User.AccountType.LIBRARY)
+        api_client.force_authenticate(user=inst)
+
+        donation = DonationFactory(donor=donor, recipient=inst, status=Donation.Status.OFFERED)
+        url = reverse('donation-decline', kwargs={'pk': donation.pk})
+        api_client.post(url)
+
+        donor.refresh_from_db()
+        assert donor.gifts_given_count == 0

--- a/apps/donations/tests/test_serializers.py
+++ b/apps/donations/tests/test_serializers.py
@@ -59,6 +59,16 @@ class TestDonationSerializers:
         assert not serializer.is_valid()
         assert 'user_book_id' in serializer.errors
 
+    def test_self_gifting_rejected(self):
+        donor = UserFactory()
+        ub = UserBookFactory(user=donor, status=UserBook.Status.AVAILABLE)
+
+        request = MagicMock(user=donor)
+        data = {"recipient_id": str(donor.id), "user_book_id": str(ub.id)}
+        serializer = DonationCreateSerializer(data=data, context={'request': request})
+        assert not serializer.is_valid()
+        assert 'recipient_id' in serializer.errors
+
     def test_donation_create_condition_validation_for_individual(self):
         donor = UserFactory()
         recipient = UserFactory()

--- a/apps/inventory/tests/test_wanted_by.py
+++ b/apps/inventory/tests/test_wanted_by.py
@@ -1,0 +1,102 @@
+import pytest
+from django.urls import reverse
+from rest_framework import status
+
+from apps.inventory.models import UserBook, ConditionChoices
+from apps.accounts.models import User
+from apps.tests.factories import UserFactory, UserBookFactory, WishlistItemFactory
+
+
+@pytest.mark.django_db
+class TestBookWantedByView:
+    def _url(self, user_book_id):
+        return reverse('my-book-wanted-by', kwargs={'pk': user_book_id})
+
+    def test_requires_authentication(self, api_client):
+        ub = UserBookFactory()
+        response = api_client.get(self._url(ub.pk))
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_returns_wishlist_users(self, api_client):
+        owner = UserFactory()
+        wanter = UserFactory()
+        ub = UserBookFactory(user=owner, status=UserBook.Status.AVAILABLE)
+        WishlistItemFactory(user=wanter, book=ub.book, min_condition=ConditionChoices.GOOD)
+
+        api_client.force_authenticate(user=owner)
+        response = api_client.get(self._url(ub.pk))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]['user']['id'] == str(wanter.id)
+        assert response.data[0]['min_condition'] == ConditionChoices.GOOD
+
+    def test_excludes_owner_from_results(self, api_client):
+        owner = UserFactory()
+        ub = UserBookFactory(user=owner, status=UserBook.Status.AVAILABLE)
+        WishlistItemFactory(user=owner, book=ub.book)
+
+        api_client.force_authenticate(user=owner)
+        response = api_client.get(self._url(ub.pk))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 0
+
+    def test_excludes_inactive_wishlist_items(self, api_client):
+        owner = UserFactory()
+        wanter = UserFactory()
+        ub = UserBookFactory(user=owner, status=UserBook.Status.AVAILABLE)
+        WishlistItemFactory(user=wanter, book=ub.book, is_active=False)
+
+        api_client.force_authenticate(user=owner)
+        response = api_client.get(self._url(ub.pk))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 0
+
+    def test_returns_404_for_another_users_book(self, api_client):
+        owner = UserFactory()
+        other = UserFactory()
+        ub = UserBookFactory(user=owner, status=UserBook.Status.AVAILABLE)
+
+        api_client.force_authenticate(user=other)
+        response = api_client.get(self._url(ub.pk))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_404_for_unavailable_book(self, api_client):
+        owner = UserFactory()
+        ub = UserBookFactory(user=owner, status=UserBook.Status.RESERVED)
+
+        api_client.force_authenticate(user=owner)
+        response = api_client.get(self._url(ub.pk))
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_returns_multiple_wanters_with_varying_conditions(self, api_client):
+        owner = UserFactory()
+        ub = UserBookFactory(user=owner, status=UserBook.Status.AVAILABLE)
+        WishlistItemFactory(user=UserFactory(), book=ub.book, min_condition=ConditionChoices.LIKE_NEW)
+        WishlistItemFactory(user=UserFactory(), book=ub.book, min_condition=ConditionChoices.GOOD)
+        WishlistItemFactory(user=UserFactory(), book=ub.book, min_condition=ConditionChoices.ACCEPTABLE)
+
+        api_client.force_authenticate(user=owner)
+        response = api_client.get(self._url(ub.pk))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 3
+        conditions = {entry['min_condition'] for entry in response.data}
+        assert conditions == {ConditionChoices.LIKE_NEW, ConditionChoices.GOOD, ConditionChoices.ACCEPTABLE}
+
+    def test_includes_institution_wanters(self, api_client):
+        owner = UserFactory()
+        lib = UserFactory(account_type=User.AccountType.LIBRARY, is_verified=True)
+        ub = UserBookFactory(user=owner, status=UserBook.Status.AVAILABLE)
+        WishlistItemFactory(user=lib, book=ub.book)
+
+        api_client.force_authenticate(user=owner)
+        response = api_client.get(self._url(ub.pk))
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.data) == 1
+        assert response.data[0]['user']['id'] == str(lib.id)


### PR DESCRIPTION
## Summary

- **Karma**: each completed trade = 1 point, each book gifted = 2 points (`total_trades + gifts_given_count × 2`). Displayed prominently on public profiles with a tooltip explaining the formula.
- **Percentile badges**: nightly Django-Q2 task assigns `top_10` / `top_25` badges independently for givers (by `gifts_given_count`) and traders (by `total_trades`). Only active, email-verified individual users are ranked; users with 0 in the relevant metric are excluded.
- **Community page** (`/community`): sortable by karma (default), trades, gifts, rating, or newest; filterable by badge and "has books available"; username search; paginated user cards.
- **Gift condition validation**: `DonationCreateSerializer` now rejects gift offers where the donor's book condition falls below the recipient's `min_condition` wishlist preference.
- **Test coverage**: nightly badge task (10 tests), community view (12 tests), `wanted-by` endpoint (8 tests), gifting edge cases (decline doesn't award karma, self-gifting rejected).

## What karma does NOT include
- 5-star reviews (avg_recent_rating is already surfaced separately)
- Gifts received (intentional — receiving is not penalised or rewarded)

## Implementation notes
- `gifts_given_count` is incremented atomically (via `F()`) inside `DonationAcceptView`'s existing `atomic()` block — covers both institution donations and peer-to-peer gifts
- Badge recalculation scheduled via migration (same pattern as nightly backup task)
- Community list annotates `karma_score` and `has_available_books` in the queryset rather than storing karma as a field, keeping it always in sync
- FAQ entry added to README

## Test plan
- [ ] Backend pytest passes (karma fields, badge task, community view, wanted-by, gifting edge cases)
- [ ] Frontend vitest passes (Community page component)
- [ ] E2E Playwright passes
- [ ] Profile page shows ✦ karma, badge chips, tooltip
- [ ] Community page sorts/filters correctly
- [ ] Accepting a donation increments donor karma; declining does not

https://claude.ai/code/session_01GfNjTQXpcBxnyXiVk8Xo2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfNjTQXpcBxnyXiVk8Xo2U)_