### PR TITLE
Support versioned PostgreSQL names in Nix store lookup

### DIFF
--- a/apps/backups/tests/test_find_pg_tool.py
+++ b/apps/backups/tests/test_find_pg_tool.py
@@ -37,6 +37,18 @@ class TestFindPgTool:
         ):
             assert _find_pg_tool("pg_dump") == store_path
 
+    def test_nix_store_versioned_name_fallback(self):
+        # Railway/Nixpacks may name the store entry 'postgresql_16' not 'postgresql'
+        store_path = "/nix/store/xyz-postgresql_16-16.3/bin/pg_dump"
+        def _glob(pattern):
+            return [store_path] if "postgresql_" in pattern else []
+        with (
+            patch("config.settings.base.shutil.which", return_value=None),
+            patch("config.settings.base.os.path.isfile", return_value=False),
+            patch("config.settings.base.glob.glob", side_effect=_glob),
+        ):
+            assert _find_pg_tool("pg_dump") == store_path
+
     def test_bare_name_fallback_when_not_found(self):
         with (
             patch("config.settings.base.shutil.which", return_value=None),

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -272,14 +272,21 @@ def _find_pg_tool(name: str) -> str:
     for nix_profile in (
         "/root/.nix-profile/bin",
         "/nix/var/nix/profiles/default/bin",
+        "/nix/var/nix/profiles/system/sw/bin",
     ):
         candidate = f"{nix_profile}/{name}"
         if os.path.isfile(candidate):
             return candidate
-    # Nix store glob (hash changes per build, so match any version)
-    matches = glob.glob(f"/nix/store/*-postgresql-*/bin/{name}")
-    if matches:
-        return matches[0]
+    # Nix store glob — '*-postgresql-*' misses versioned names like
+    # 'postgresql_16' or 'postgresql16' that Nixpacks may use. Try all variants.
+    for pattern in (
+        f"/nix/store/*-postgresql-*/bin/{name}",   # e.g. postgresql-16.3
+        f"/nix/store/*-postgresql_*-*/bin/{name}", # e.g. postgresql_16-16.3
+        f"/nix/store/*-postgresql[0-9]*-*/bin/{name}", # e.g. postgresql16-16.3
+    ):
+        matches = glob.glob(pattern)
+        if matches:
+            return matches[0]
     return name  # fall back to bare name; will fail with a clear OS error if missing
 
 DBBACKUP_CONNECTORS = {


### PR DESCRIPTION
## Summary
Fixes PostgreSQL tool discovery in Nix environments where Nixpacks uses versioned package names like `postgresql_16` or `postgresql16` instead of the standard `postgresql` naming convention.

## Changes
- **config/settings/base.py**: Enhanced `_find_pg_tool()` to search multiple Nix store glob patterns:
  - Added `/nix/var/nix/profiles/system/sw/bin` to the standard Nix profile search paths
  - Replaced single glob pattern with three variants to match:
    - Standard names: `postgresql-16.3`
    - Underscore-versioned: `postgresql_16-16.3` (Railway/Nixpacks convention)
    - Digit-suffixed: `postgresql16-16.3`
  - Updated comment to clarify why multiple patterns are needed

- **apps/backups/tests/test_find_pg_tool.py**: Added test case `test_nix_store_versioned_name_fallback()` to verify the function correctly discovers PostgreSQL tools with versioned naming schemes

## Implementation Details
The function now iterates through multiple glob patterns in order, returning the first match found. This maintains backward compatibility with existing Nix setups while supporting the versioned naming conventions used by Nixpacks deployments (e.g., on Railway).

https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp