### PR TITLE
Fix pg_dump discovery: bash login-shell fallback + check_backups diagnostics

### DIFF
--- a/apps/backups/management/commands/check_backups.py
+++ b/apps/backups/management/commands/check_backups.py
@@ -1,4 +1,6 @@
+import os
 import shutil
+import subprocess
 
 from django.conf import settings
 from django.core.management.base import BaseCommand
@@ -27,6 +29,16 @@ class Command(BaseCommand):
                 "  Railway/Nixpacks: add 'postgresql' to pkgs in nixpacks.toml\n"
                 "  Docker: RUN apt-get install -y postgresql-client"
             ))
+            self.stdout.write(f"  PATH: {os.environ.get('PATH', '(not set)')}")
+            try:
+                result = subprocess.run(
+                    ["find", "/usr", "/nix", "-name", "pg_dump", "-type", "f"],
+                    capture_output=True, text=True, timeout=15,
+                )
+                found = result.stdout.strip()
+                self.stdout.write(f"  find /usr /nix -name pg_dump: {found or '(nothing found)'}")
+            except Exception as exc:
+                self.stdout.write(f"  find: {exc}")
 
         if shutil.which(pg_restore_cmd):
             self.stdout.write(self.style.SUCCESS(f"pg_restore: FOUND ({pg_restore_cmd})"))

--- a/apps/backups/tests/test_find_pg_tool.py
+++ b/apps/backups/tests/test_find_pg_tool.py
@@ -49,10 +49,23 @@ class TestFindPgTool:
         ):
             assert _find_pg_tool("pg_dump") == store_path
 
-    def test_bare_name_fallback_when_not_found(self):
+    def test_bash_login_shell_fallback(self):
+        bash_path = "/nix/var/nix/profiles/default/bin/pg_dump"
+        mock_result = type("R", (), {"returncode": 0, "stdout": bash_path + "\n"})()
         with (
             patch("config.settings.base.shutil.which", return_value=None),
             patch("config.settings.base.os.path.isfile", return_value=False),
             patch("config.settings.base.glob.glob", return_value=[]),
+            patch("config.settings.base.subprocess.run", return_value=mock_result),
+        ):
+            assert _find_pg_tool("pg_dump") == bash_path
+
+    def test_bare_name_fallback_when_not_found(self):
+        mock_result = type("R", (), {"returncode": 1, "stdout": ""})()
+        with (
+            patch("config.settings.base.shutil.which", return_value=None),
+            patch("config.settings.base.os.path.isfile", return_value=False),
+            patch("config.settings.base.glob.glob", return_value=[]),
+            patch("config.settings.base.subprocess.run", return_value=mock_result),
         ):
             assert _find_pg_tool("pg_dump") == "pg_dump"

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import shutil
+import subprocess
 from datetime import timedelta
 from pathlib import Path
 
@@ -287,6 +288,17 @@ def _find_pg_tool(name: str) -> str:
         matches = glob.glob(pattern)
         if matches:
             return matches[0]
+    # Last resort: ask bash — it sources Nix profiles that may not appear in the
+    # Python process PATH (e.g. when gunicorn is started without a login shell).
+    try:
+        result = subprocess.run(
+            ["bash", "-lc", f"which {name}"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if result.returncode == 0 and (found := result.stdout.strip()):
+            return found
+    except Exception:
+        pass
     return name  # fall back to bare name; will fail with a clear OS error if missing
 
 DBBACKUP_CONNECTORS = {


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **`config/settings/base.py`**: Added `bash -lc "which pg_dump"` as a final fallback in `_find_pg_tool`. The `-l` (login shell) flag causes bash to source `/etc/profile.d` and Nix activation scripts, making Nixpacks-installed binaries visible — something `shutil.which` misses because gunicorn isn't started as a login shell.
- **`check_backups` command**: When pg_dump is NOT FOUND, now prints the process `PATH` and runs `find /usr /nix -name pg_dump` so future failures show exactly where the binary lives (or confirm it isn't installed).
- **Tests**: Added regression tests for the bash fallback and the versioned Nix store path (`postgresql_16`) cases.

## Test plan

- [ ] Deploy to Railway and run `python manage.py check_backups` — pg_dump should show as FOUND
- [ ] If still NOT FOUND, the new diagnostic output (PATH + find results) will show exactly what's available in the container
- [ ] Run `pytest apps/backups/tests/test_find_pg_tool.py -v` to verify all unit tests pass

https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp)_