### PR TITLE
Install postgresql-client via railway.toml buildCommand

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,5 @@
 [build]
-buildCommand = "pip install -r requirements.txt && python manage.py collectstatic --noinput"
+buildCommand = "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-client libzbar0 && pip install -r requirements.txt && python manage.py collectstatic --noinput"
 
 [deploy]
 startCommand = "bash start.sh"


### PR DESCRIPTION
## Summary

- **Root cause identified**: Railway switched to its native mise-based builder, which ignores `nixpacks.toml` entirely. Neither `postgresql-client` (needed for `pg_dump`/`pg_restore`) nor `libzbar0` (needed by pyzbar for ISBN barcode scanning) were being installed in the container.
- **Fix**: Move system package installation into `railway.toml`'s `buildCommand` — the only build hook Railway's native builder actually executes.

## What changed

`railway.toml` `buildCommand` now runs:
```
apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-client libzbar0 && pip install -r requirements.txt && python manage.py collectstatic --noinput
```

## Test plan

- [ ] Deploy to Railway and run `python manage.py check_backups` — pg_dump and pg_restore should show as FOUND
- [ ] Trigger a manual backup from the admin panel and confirm it succeeds
- [ ] Confirm ISBN barcode scanning still works (libzbar0 restored)

https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp)_