### PR TITLE
Force Nixpacks builder so nixpacks.toml aptPkgs are installed

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,5 +1,6 @@
 [build]
-buildCommand = "apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-client libzbar0 && pip install -r requirements.txt && python manage.py collectstatic --noinput"
+builder = "NIXPACKS"
+buildCommand = "pip install -r requirements.txt && python manage.py collectstatic --noinput"
 
 [deploy]
 startCommand = "bash start.sh"


### PR DESCRIPTION
## Summary

**Root cause (final):** Railway's native (mise) builder copies only the virtualenv into the runtime image. `apt-get install` in `buildCommand` runs in an ephemeral build container and doesn't persist — which is why `find /usr /nix -name pg_dump` still returns nothing after the previous fix.

**Fix:** Add `builder = "NIXPACKS"` to `railway.toml`. This forces Railway to use Nixpacks, which bakes `aptPkgs` from `nixpacks.toml` into the runtime image. The `nixpacks.toml` already has the correct configuration (`postgresql-client`, `libzbar0`, `postgresql`) — it just wasn't being used because Railway had switched to its native builder.

Also reverts the `apt-get` call added to `buildCommand` in the previous PR — it's now handled by `nixpacks.toml` and was a no-op with the native builder.

## Test plan

- [ ] Deploy to Railway and run `python manage.py check_backups` — pg_dump and pg_restore should show as FOUND with a resolved path
- [ ] Trigger a manual backup from the admin panel and confirm it succeeds
- [ ] Confirm ISBN barcode scanning still works (libzbar0 restored)

https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp)_