### PR TITLE
fix: correct account type display for libraries and bookstores

### DIFF
--- a/frontend/src/pages/AccountSettings.jsx
+++ b/frontend/src/pages/AccountSettings.jsx
@@ -210,7 +210,11 @@ export default function AccountSettings() {
                         </div>
                         <div>
                             <dt>Account type</dt>
-                            <dd>{account?.account_type === 'institution' ? 'Institution' : 'Individual'}</dd>
+                            <dd>
+                                {['library', 'bookstore'].includes(account?.account_type)
+                                    ? account.account_type.charAt(0).toUpperCase() + account.account_type.slice(1)
+                                    : 'Individual'}
+                            </dd>
                         </div>
                         {account?.institution_name && (
                             <div>

--- a/frontend/src/pages/AccountSettings.test.jsx
+++ b/frontend/src/pages/AccountSettings.test.jsx
@@ -208,7 +208,7 @@ describe('AccountSettings page', () => {
         expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
     });
 
-    it('shows institution name when account is an institution type', async () => {
+    it('shows specific institution type when account is a library', async () => {
         usersApi.getMe.mockResolvedValueOnce({
             data: {
                 id: 'user-1',
@@ -227,9 +227,29 @@ describe('AccountSettings page', () => {
         });
         renderWithProviders(<AccountSettings />);
         expect(await screen.findByText('City Central Library')).toBeInTheDocument();
-        // "Institution" appears as both label (dt) and value (dd) — use a more specific query
-        const dd = document.querySelector('dd');
-        expect(dd).toBeTruthy(); // account type dd rendered
+        expect(screen.getByText('Library')).toBeInTheDocument();
+    });
+
+    it('shows specific institution type when account is a bookstore', async () => {
+        usersApi.getMe.mockResolvedValueOnce({
+            data: {
+                id: 'user-1',
+                username: 'bookstore1',
+                email: 'books@example.com',
+                account_type: 'bookstore',
+                institution_name: 'Downtown Books',
+                full_name: '',
+                address_line_1: '',
+                address_line_2: '',
+                city: '',
+                state: '',
+                zip_code: '',
+                address_verification_status: 'unverified',
+            },
+        });
+        renderWithProviders(<AccountSettings />);
+        expect(await screen.findByText('Downtown Books')).toBeInTheDocument();
+        expect(screen.getByText('Bookstore')).toBeInTheDocument();
     });
 
     it('shows USPS error in form area after failed address verification', async () => {

--- a/frontend/src/pages/AccountSettings.test.jsx
+++ b/frontend/src/pages/AccountSettings.test.jsx
@@ -214,7 +214,7 @@ describe('AccountSettings page', () => {
                 id: 'user-1',
                 username: 'library1',
                 email: 'lib@example.com',
-                account_type: 'institution',
+                account_type: 'library',
                 institution_name: 'City Central Library',
                 full_name: '',
                 address_line_1: '',

--- a/frontend/src/pages/Institutions.jsx
+++ b/frontend/src/pages/Institutions.jsx
@@ -134,9 +134,9 @@ function InstitutionCard({ institution }) {
           {institution.is_verified && (
             <span className="badge badge-green">Verified</span>
           )}
-          {institution.institution_type && (
+          {(institution.account_type || institution.institution_type) && (
             <span className="badge badge-blue">
-              {institution.institution_type}
+              {institution.account_type || institution.institution_type}
             </span>
           )}
         </div>

--- a/frontend/src/pages/PublicProfile.jsx
+++ b/frontend/src/pages/PublicProfile.jsx
@@ -93,7 +93,7 @@ export default function PublicProfile() {
   const { data: wantedData } = useQuery({
     queryKey: ['institutionWanted', id],
     queryFn: () => institutionsApi.getWantedList(id, { page_size: 20 }).then((r) => r.data),
-    enabled: !!profile && profile.account_type === 'institution',
+    enabled: !!profile && ['library', 'bookstore'].includes(profile.account_type),
   });
 
   const { data: offeredBooksData } = useQuery({
@@ -105,7 +105,7 @@ export default function PublicProfile() {
   const { data: publicWantedData } = useQuery({
     queryKey: ['userWantedBooks', id],
     queryFn: () => usersApi.getUserWantedBooks(id).then((r) => r.data),
-    enabled: !!profile && profile.account_type !== 'institution',
+    enabled: !!profile && !['library', 'bookstore'].includes(profile.account_type),
   });
 
   const { data: meData } = useQuery({
@@ -190,7 +190,7 @@ export default function PublicProfile() {
   const wantedBooks = wantedData?.results ?? wantedData ?? [];
   const offeredBooks = offeredBooksData ?? [];
   const publicWantedBooks = publicWantedData ?? [];
-  const isInstitution = profile.account_type === 'institution';
+  const isInstitution = ['library', 'bookstore'].includes(profile.account_type);
   const hasOwnAddress = Boolean(
     meData?.address_line_1 && meData?.city && meData?.state && meData?.zip_code
   );
@@ -235,7 +235,9 @@ export default function PublicProfile() {
           <div className={styles.nameRow}>
             <h1 className={styles.username}>@{profile.username}</h1>
             {isInstitution && (
-              <span className="badge badge-blue">Institution</span>
+              <span className="badge badge-blue">
+                {profile.account_type.charAt(0).toUpperCase() + profile.account_type.slice(1)}
+              </span>
             )}
             {profile.is_verified && (
               <Tooltip content="This institution's identity has been confirmed by BookForBook.">

--- a/frontend/src/pages/PublicProfile.test.jsx
+++ b/frontend/src/pages/PublicProfile.test.jsx
@@ -54,7 +54,7 @@ describe('PublicProfile page', () => {
             data: {
                 id: 'institution-1',
                 username: 'central-library',
-                account_type: 'institution',
+                account_type: 'library',
                 is_verified: true,
                 total_trades: 12,
             },
@@ -144,7 +144,7 @@ describe('PublicProfile page', () => {
             data: {
                 id: 'institution-1',
                 username: 'central-library',
-                account_type: 'institution',
+                account_type: 'library',
                 is_verified: true,
                 total_trades: 12,
             },
@@ -730,7 +730,7 @@ describe('PublicProfile page', () => {
         useAuth.mockReturnValue({ isAuthenticated: false, user: null });
 
         users.getPublicProfile.mockResolvedValue({
-            data: { id: 'institution-1', username: 'central-lib', account_type: 'institution', is_verified: true, total_trades: 5 },
+            data: { id: 'institution-1', username: 'central-lib', account_type: 'library', is_verified: true, total_trades: 5 },
         });
         users.getUserRatings.mockResolvedValue({ data: [] });
         institutions.getWantedList.mockResolvedValue({

--- a/frontend/src/pages/PublicProfile.test.jsx
+++ b/frontend/src/pages/PublicProfile.test.jsx
@@ -49,6 +49,27 @@ describe('PublicProfile page', () => {
         users.getUserWantedBooks.mockResolvedValue({ data: [] });
     });
 
+    it('renders bookstore type badge on the public profile', async () => {
+        useParams.mockReturnValue({ id: 'bookstore-1' });
+        useAuth.mockReturnValue({ isAuthenticated: false, user: null });
+
+        users.getPublicProfile.mockResolvedValue({
+            data: {
+                id: 'bookstore-1',
+                username: 'cool-books',
+                account_type: 'bookstore',
+                is_verified: true,
+                total_trades: 5,
+            },
+        });
+        users.getUserRatings.mockResolvedValue({ data: [] });
+
+        renderWithProviders(<PublicProfile />);
+
+        expect(await screen.findByText('@cool-books')).toBeInTheDocument();
+        expect(screen.getByText('Bookstore')).toBeInTheDocument();
+    });
+
     it('renders institution wanted books from the current API shape', async () => {
         users.getPublicProfile.mockResolvedValue({
             data: {
@@ -155,6 +176,7 @@ describe('PublicProfile page', () => {
         renderWithProviders(<PublicProfile />);
 
         expect(await screen.findByText('@central-library')).toBeInTheDocument();
+        expect(screen.getByText('Library')).toBeInTheDocument();
         expect(screen.queryByText('Shipping Address')).not.toBeInTheDocument();
         expect(screen.queryByText('Wishlist Match Preferences')).not.toBeInTheDocument();
         expect(users.getMe).not.toHaveBeenCalled();


### PR DESCRIPTION
This fix addresses an issue where institutional accounts (libraries and bookstores) were incorrectly displayed as "Individual" on the profile and settings pages. The frontend was looking for a generic "institution" value, whereas the backend returns specific types. Updated the logic to recognize "library" and "bookstore" as institutions and show their specific type badge.
