### PR TITLE
Switch to Dockerfile builder to fix Django and pg_dump in Railway

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        postgresql-client \
+        libzbar0 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .

--- a/railway.toml
+++ b/railway.toml
@@ -1,6 +1,5 @@
 [build]
-builder = "NIXPACKS"
-buildCommand = "pip install -r requirements.txt && python manage.py collectstatic --noinput"
+builder = "DOCKERFILE"
 
 [deploy]
 startCommand = "bash start.sh"

--- a/start.sh
+++ b/start.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+# Collect static files (runs here because Railway env vars aren't available during Docker build)
+python manage.py collectstatic --noinput
+
 # Run migrations
 python manage.py migrate --noinput
 


### PR DESCRIPTION
## Summary

- **Root cause**: Railway's native (mise) builder uses a two-stage build — `apt-get install` runs in the build stage but only the virtualenv is copied to the runtime image, so system packages like `postgresql-client` are lost. Switching to Nixpacks made things worse: Nixpacks' Nix-provided Python has a read-only site-packages, so `pip install` had nowhere to write and Django wasn't importable at all.
- **Fix**: A `Dockerfile` gives us a single image layer where both `apt-get` (system packages) and `pip install` (Python packages) write to the same filesystem that becomes the runtime container.

## Changes

- **`Dockerfile`** (new): `python:3.12-slim` base, installs `postgresql-client` and `libzbar0`, then `pip install -r requirements.txt`
- **`railway.toml`**: `builder = "DOCKERFILE"`, `buildCommand` removed (Dockerfile handles it)
- **`start.sh`**: adds `collectstatic` — moved here from `buildCommand` because Railway env vars (`SECRET_KEY`, `DATABASE_URL`, etc.) aren't available during Docker `RUN` steps, only at runtime

## Test plan

- [ ] Deploy to Railway and run `python manage.py check_backups` — pg_dump and pg_restore should show as FOUND
- [ ] Trigger a manual backup from the admin panel and confirm it succeeds
- [ ] Confirm the app loads normally (Django importable, migrations run, gunicorn starts)
- [ ] Confirm ISBN barcode scanning still works (`libzbar0` installed)

https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDssS9SMUNcNW4oPBMP7Bp)_