### PR TITLE
Change default wishlist minimum condition from 'any' to 'good'

### DIFF
--- a/frontend/src/pages/Wishlist.jsx
+++ b/frontend/src/pages/Wishlist.jsx
@@ -57,7 +57,7 @@ function normalizePhysicalFormatToKey(physicalFormat) {
 }
 
 const DEFAULT_WISHLIST_PREFERENCES = {
-  min_condition: 'any',
+  min_condition: 'good',
   edition_preference: 'same_language',
   allow_translations: false,
   exclude_abridged: true,


### PR DESCRIPTION
## Summary
Updates the default minimum condition preference for new wishlists from `'any'` to `'good'`, raising the baseline quality expectation for books users want to receive.

## Changes
- Modified `DEFAULT_WISHLIST_PREFERENCES` in `frontend/src/pages/Wishlist.jsx` to set `min_condition: 'good'` instead of `'any'`

## Details
This change affects the initial wishlist preferences for new users or when preferences are reset. Users will now default to accepting books in "good" condition or better, rather than any condition. Users can still manually adjust this preference to a lower standard if desired.

https://claude.ai/code/session_015E5v3DdMEKUuPYEganCqpZ