### PR TITLE
Prevent duplicate notifications with identical messages

### DIFF
--- a/frontend/src/hooks/useNotification.js
+++ b/frontend/src/hooks/useNotification.js
@@ -4,9 +4,10 @@ const useNotificationStore = create((set) => ({
   notifications: [],
   addNotification: (message, type = 'info', duration = 5000) => {
     const id = Date.now();
-    set((state) => ({
-      notifications: [...state.notifications, { id, message, type }],
-    }));
+    set((state) => {
+      if (state.notifications.some((n) => n.message === message)) return state;
+      return { notifications: [...state.notifications, { id, message, type }] };
+    });
     if (duration > 0) {
       setTimeout(() => {
         set((state) => ({

--- a/frontend/src/hooks/useNotification.test.js
+++ b/frontend/src/hooks/useNotification.test.js
@@ -86,4 +86,15 @@ describe('useNotificationStore', () => {
 
     expect(result.current.notifications).toHaveLength(3);
   });
+
+  it('does not add a duplicate notification when one with the same message is already visible', () => {
+    const { result } = renderHook(() => useNotificationStore());
+
+    act(() => {
+      result.current.addNotification('You have been automatically logged out.', 'warning');
+      result.current.addNotification('You have been automatically logged out.', 'warning');
+    });
+
+    expect(result.current.notifications).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Summary
Adds deduplication logic to the notification store to prevent multiple notifications with the same message from being displayed simultaneously.

## Changes
- **useNotification.js**: Modified `addNotification` to check if a notification with the same message already exists before adding a new one. If a duplicate is detected, the state is returned unchanged.
- **useNotification.test.js**: Added test case to verify that duplicate notifications with identical messages are not added to the store.

## Implementation Details
The deduplication check uses a simple `state.notifications.some()` predicate to detect existing notifications by message content. This prevents scenarios like repeated "You have been automatically logged out" messages from cluttering the UI while maintaining the ability to show multiple notifications with different messages.

https://claude.ai/code/session_01CDFwh3VGj7XraSoeTaKow3