### PR TITLE
Reorganize navbar navigation: move Matches/Trades to user menu

### DIFF
--- a/frontend/e2e/specs/critical/08-notifications.spec.js
+++ b/frontend/e2e/specs/critical/08-notifications.spec.js
@@ -8,6 +8,7 @@
  *   - Notifications API endpoint is called
  */
 import { test, expect } from '../../fixtures/index.js';
+import { ALICE } from '../../constants.js';
 
 test.describe('Notifications', () => {
   test('notification bell visible for authenticated user', async ({ alicePage: page }) => {
@@ -66,16 +67,16 @@ test.describe('Notifications', () => {
     await expect(page.getByRole('button', { name: /notifications/i })).toHaveCount(0);
   });
 
-  test('pending match count badge shows in navbar matches link', async ({
+  test('pending match count badge shows in user menu matches link', async ({
     alicePage: page,
   }) => {
-    // The Matches nav link shows a badge when total_pending > 0
-    // Alice has a seeded pending match, so badge should be visible
+    // My Matches lives in the user dropdown — open it first
     await page.goto('/dashboard');
 
-    // The badge is a <span> inside the Matches NavLink
-    // Use a broad check — either badge appears or nav link is visible
-    const matchesLink = page.getByRole('link', { name: /matches/i });
-    await expect(matchesLink).toBeVisible();
+    await page.getByRole('button', { name: new RegExp(ALICE.username, 'i') }).click();
+
+    // My Matches link should be visible in the open dropdown
+    const myMatchesLink = page.getByRole('link', { name: /my matches/i });
+    await expect(myMatchesLink).toBeVisible({ timeout: 8_000 });
   });
 });

--- a/frontend/e2e/specs/critical/12-public-profile.spec.js
+++ b/frontend/e2e/specs/critical/12-public-profile.spec.js
@@ -39,7 +39,7 @@ test.describe('Public Profile', () => {
     await page.goto(profileUrl);
     await expect(page.getByRole('heading', { name: /^@alice_e2e$/i })).toBeVisible({ timeout: 15_000 });
 
-    await expect(page.getByText(/trades/i).first()).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByText('Trades', { exact: true }).first()).toBeVisible({ timeout: 8_000 });
     await expect(page.getByText(/member since/i)).toBeVisible({ timeout: 8_000 });
   });
 

--- a/frontend/src/components/layout/Navbar.jsx
+++ b/frontend/src/components/layout/Navbar.jsx
@@ -104,17 +104,6 @@ export default function Navbar() {
               <NavLink to="/discovery" className={navLinkClass}>
                 Discover
               </NavLink>
-              <NavLink to="/matches" className={navLinkClass}>
-                Matches
-                {totalPending > 0 && (
-                  <Tooltip content={`${totalPending} match${totalPending === 1 ? '' : 'es'} waiting for your response.`} position="bottom">
-                    <span className={styles.badge}>{totalPending > 99 ? '99+' : totalPending}</span>
-                  </Tooltip>
-                )}
-              </NavLink>
-              <NavLink to="/trades" className={navLinkClass}>
-                Trades
-              </NavLink>
             </>
           )}
         </div>
@@ -211,6 +200,25 @@ export default function Navbar() {
                       My Profile
                     </Link>
                     <Link
+                      to="/matches"
+                      className={styles.dropdownItem}
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      My Matches
+                      {totalPending > 0 && (
+                        <Tooltip content={`${totalPending} match${totalPending === 1 ? '' : 'es'} waiting for your response.`} position="bottom">
+                          <span className={styles.badge}>{totalPending > 99 ? '99+' : totalPending}</span>
+                        </Tooltip>
+                      )}
+                    </Link>
+                    <Link
+                      to="/trades"
+                      className={styles.dropdownItem}
+                      onClick={() => setMenuOpen(false)}
+                    >
+                      My Trades
+                    </Link>
+                    <Link
                       to="/discovery"
                       className={styles.dropdownItem}
                       onClick={() => setMenuOpen(false)}
@@ -299,20 +307,20 @@ export default function Navbar() {
               <NavLink to="/discovery" className={navLinkClass} onClick={() => setMobileOpen(false)}>
                 Discover
               </NavLink>
-              <NavLink to="/matches" className={navLinkClass} onClick={() => setMobileOpen(false)}>
-                Matches {totalPending > 0 && `(${totalPending})`}
-              </NavLink>
               <NavLink to="/proposals" className={navLinkClass} onClick={() => setMobileOpen(false)}>
                 Proposals
-              </NavLink>
-              <NavLink to="/trades" className={navLinkClass} onClick={() => setMobileOpen(false)}>
-                Trades
               </NavLink>
               <NavLink to="/donations" className={navLinkClass} onClick={() => setMobileOpen(false)}>
                 Donations
               </NavLink>
               <NavLink to="/account" className={navLinkClass} onClick={() => setMobileOpen(false)}>
                 My Profile
+              </NavLink>
+              <NavLink to="/matches" className={navLinkClass} onClick={() => setMobileOpen(false)}>
+                My Matches {totalPending > 0 && `(${totalPending})`}
+              </NavLink>
+              <NavLink to="/trades" className={navLinkClass} onClick={() => setMobileOpen(false)}>
+                My Trades
               </NavLink>
               <button
                 className={`${styles.navLink} ${styles.mobileLogout}`}

--- a/frontend/src/components/layout/Navbar.test.jsx
+++ b/frontend/src/components/layout/Navbar.test.jsx
@@ -293,7 +293,7 @@ describe('Navbar', () => {
 
         const mobileNavLinkNames = [
             'Browse', 'Institutions', 'Dashboard', 'My Books',
-            'Wishlist', /^Matches/, 'Proposals', 'Trades', 'Donations', 'My Profile',
+            'Wishlist', 'Proposals', 'Donations', 'My Profile', /^My Matches/, 'My Trades',
         ];
 
         for (const name of mobileNavLinkNames) {

--- a/frontend/src/components/layout/Navbar.test.jsx
+++ b/frontend/src/components/layout/Navbar.test.jsx
@@ -217,8 +217,10 @@ describe('Navbar', () => {
             data: { total_pending: 100, unread_notifications: 0 },
         });
         renderWithProviders(<Navbar />);
+        // The badge lives inside the user dropdown — open it first
+        const menuButton = screen.getByRole('button', { name: /reader/i });
+        await userEvent.click(menuButton);
         await waitFor(() => {
-            // There should be a '99+' badge for the matches link
             const badges = screen.getAllByText('99+');
             expect(badges.length).toBeGreaterThan(0);
         });


### PR DESCRIPTION
## Summary
Reorganizes the navbar navigation structure to consolidate user-specific links (Matches, Trades) into the authenticated user dropdown menu, improving information hierarchy and reducing clutter in the main navigation bar.

## Key Changes
- **Desktop navbar**: Removed "Matches" and "Trades" links from the main horizontal navigation; moved them to the user profile dropdown menu as "My Matches" and "My Trades"
- **Mobile navbar**: Reordered navigation items to group user-specific links (My Matches, My Trades) together after "My Profile" for better logical grouping
- **Badge preservation**: Maintained the pending matches badge and tooltip on the "My Matches" link in the dropdown menu
- **Consistent labeling**: Updated link labels to "My Matches" and "My Trades" in dropdown and mobile menus for clarity that these are user-specific sections

## Implementation Details
- The pending matches badge (`totalPending`) and its tooltip remain functional in the new dropdown location
- Mobile menu close handlers (`onClick={() => setMobileOpen(false)}`) are preserved on all navigation links
- Dropdown menu close handlers (`onClick={() => setMenuOpen(false)}`) are applied to the relocated links
- Navigation structure now follows a pattern: public discovery links in main nav, user-specific links in authenticated menu

https://claude.ai/code/session_01MdwfafJREe1iyQD5xy5XW4