### PR TITLE
Fire background Tier 2 enrich after ISBN lookup to populate physical_format

### DIFF
--- a/frontend/src/components/common/ISBNInput.jsx
+++ b/frontend/src/components/common/ISBNInput.jsx
@@ -46,6 +46,7 @@ export default function ISBNInput({
   const fileInputRef = useRef(null);
   const uploadedPreviewUrlRef = useRef(null);
   const latestScanRequestIdRef = useRef(0);
+  const currentLookupIsbnRef = useRef(null);
 
   const displayBook = foundBook ?? localBook;
   const previewAuthor = getBookPrimaryAuthor(displayBook);
@@ -74,8 +75,17 @@ export default function ISBNInput({
       const res = await booksApi.lookupISBN(isbn);
       if (isStaleScanRequest()) return;
       const bookData = res.data;
+      currentLookupIsbnRef.current = isbn;
       setLocalBook(bookData);
       if (onBookFound) onBookFound(bookData);
+
+      // Background enrich: fills in format and other fields Tier 1 may have missed
+      booksApi.enrichISBN(isbn).then((enrichRes) => {
+        if (currentLookupIsbnRef.current !== isbn) return;
+        const enriched = enrichRes.data;
+        setLocalBook(enriched);
+        if (onBookFound) onBookFound(enriched);
+      }).catch(() => {});
     } catch (err) {
       if (isStaleScanRequest()) return;
       const msg =
@@ -84,6 +94,7 @@ export default function ISBNInput({
         'Book not found for this ISBN.';
       setLookupError(msg);
       setLocalBook(null);
+      currentLookupIsbnRef.current = null;
       if (onBookFound) onBookFound(null);
     } finally {
       if (!isStaleScanRequest()) {
@@ -114,6 +125,7 @@ export default function ISBNInput({
     onChange(e.target.value.trim());
     if (localBook) {
       setLocalBook(null);
+      currentLookupIsbnRef.current = null;
       if (onBookFound) onBookFound(null);
     }
     setIsbnCandidates(null);

--- a/frontend/src/components/common/ISBNInput.jsx
+++ b/frontend/src/components/common/ISBNInput.jsx
@@ -78,14 +78,6 @@ export default function ISBNInput({
       currentLookupIsbnRef.current = isbn;
       setLocalBook(bookData);
       if (onBookFound) onBookFound(bookData);
-
-      // Background enrich: fills in format and other fields Tier 1 may have missed
-      booksApi.enrichISBN(isbn).then((enrichRes) => {
-        if (currentLookupIsbnRef.current !== isbn) return;
-        const enriched = enrichRes.data;
-        setLocalBook(enriched);
-        if (onBookFound) onBookFound(enriched);
-      }).catch(() => {});
     } catch (err) {
       if (isStaleScanRequest()) return;
       const msg =
@@ -100,6 +92,20 @@ export default function ISBNInput({
       if (!isStaleScanRequest()) {
         setLooking(false);
       }
+    }
+
+    // Background enrich outside the try/catch so any error here never clears
+    // the book state set above. Wrapping in Promise.resolve ensures a sync
+    // throw from a missing/unmocked enrichISBN is caught by .catch().
+    if (currentLookupIsbnRef.current === isbn) {
+      Promise.resolve().then(async () => {
+        const enrichRes = await booksApi.enrichISBN(isbn);
+        if (currentLookupIsbnRef.current !== isbn) return;
+        const enriched = enrichRes?.data;
+        if (!enriched?.title) return;
+        setLocalBook(enriched);
+        if (onBookFound) onBookFound(enriched);
+      }).catch(() => {});
     }
   }
 

--- a/frontend/src/components/common/ISBNInput.test.jsx
+++ b/frontend/src/components/common/ISBNInput.test.jsx
@@ -7,6 +7,7 @@ import ISBNInput from './ISBNInput.jsx';
 vi.mock('../../services/api.js', () => ({
     books: {
         lookupISBN: vi.fn(),
+        enrichISBN: vi.fn().mockResolvedValue({ data: {} }),
         fromImage: vi.fn(),
     },
 }));


### PR DESCRIPTION
The minimal lookup (Tier 1) often returns null physical_format because the
ISBN and search endpoints frequently omit it. After the fast lookup returns,
fire enrichISBN in the background so format (and other Tier 2 fields) fill
in without blocking the initial UI response. A ref guards against stale
updates if the user changes the ISBN before enrichment completes.

https://claude.ai/code/session_01LBqxBnhJniDzRLM24fPHhi