### PR TITLE
Fix pg_dump version mismatch when server runs PostgreSQL 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,15 @@ WORKDIR /app
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        postgresql-client \
+        curl \
+        gnupg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc \
+       | gpg --dearmor -o /usr/share/keyrings/pgdg.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/pgdg.gpg] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" \
+       > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        postgresql-client-18 \
         libzbar0 \
     && rm -rf /var/lib/apt/lists/*
 

--- a/apps/backups/tests/test_find_pg_tool.py
+++ b/apps/backups/tests/test_find_pg_tool.py
@@ -6,15 +6,36 @@ from config.settings.base import _find_pg_tool
 
 @pytest.mark.unit
 class TestFindPgTool:
-    def test_found_on_path(self):
-        with patch("config.settings.base.shutil.which", return_value="/usr/bin/pg_dump"):
+    def test_versioned_debian_path_preferred_over_path(self):
+        # Versioned Debian path takes priority even when shutil.which finds something.
+        target = "/usr/lib/postgresql/18/bin/pg_dump"
+        with (
+            patch("config.settings.base.os.path.isfile", side_effect=lambda p: p == target),
+            patch("config.settings.base.shutil.which", return_value="/usr/bin/pg_dump"),
+        ):
+            assert _find_pg_tool("pg_dump") == target
+
+    def test_higher_version_wins_when_multiple_exist(self):
+        # When 17 and 16 both exist, 17 wins (range iterates high to low).
+        available = {
+            "/usr/lib/postgresql/17/bin/pg_dump",
+            "/usr/lib/postgresql/16/bin/pg_dump",
+        }
+        with patch("config.settings.base.os.path.isfile", side_effect=lambda p: p in available):
+            assert _find_pg_tool("pg_dump") == "/usr/lib/postgresql/17/bin/pg_dump"
+
+    def test_found_on_path_when_no_versioned_binary(self):
+        # Falls back to PATH when no versioned Debian binary is present.
+        with (
+            patch("config.settings.base.os.path.isfile", return_value=False),
+            patch("config.settings.base.shutil.which", return_value="/usr/bin/pg_dump"),
+        ):
             assert _find_pg_tool("pg_dump") == "/usr/bin/pg_dump"
 
-    def test_debian_apt_fallback(self):
-        # Matches /usr/lib/postgresql/14/bin/pg_dump (first existing version wins)
+    def test_debian_apt_path(self):
+        # Versioned Debian path is found (highest matching version returned).
         target = "/usr/lib/postgresql/14/bin/pg_dump"
         with (
-            patch("config.settings.base.shutil.which", return_value=None),
             patch("config.settings.base.os.path.isfile", side_effect=lambda p: p == target),
         ):
             assert _find_pg_tool("pg_dump") == target

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -262,13 +262,17 @@ DBBACKUP_STORAGE_OPTIONS = {"location": str(BASE_DIR / "backups")}
 # it is not on the default PATH (common on Railway / Nixpacks builds where the
 # Nix store puts PostgreSQL binaries outside /usr/bin).
 def _find_pg_tool(name: str) -> str:
-    if path := shutil.which(name):
-        return path
-    # Debian/Ubuntu apt paths (/usr/lib/postgresql/<version>/bin/)
+    # Debian/Ubuntu apt paths checked first so a versioned installation
+    # (e.g. postgresql-client-18) wins over whatever happens to be on PATH,
+    # which may be a lower version from a different package.
     for version in range(18, 11, -1):
         candidate = f"/usr/lib/postgresql/{version}/bin/{name}"
         if os.path.isfile(candidate):
             return candidate
+    # Fall back to PATH — correct when the binary is installed system-wide
+    # (e.g. via alternatives) and no versioned path was found above.
+    if path := shutil.which(name):
+        return path
     # Nix profile paths (Railway/Nixpacks runtime)
     for nix_profile in (
         "/root/.nix-profile/bin",

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -5,7 +5,7 @@
 #
 # Both aptPkgs (Debian/Ubuntu) and pkgs (Nix) are listed because Railway's
 # Nixpacks provider can use either backend depending on the build environment.
-aptPkgs = ["libzbar0", "postgresql-client"]
+aptPkgs = ["libzbar0", "postgresql-client-18"]
 pkgs = ["zbar", "postgresql"]
 
 [variables]


### PR DESCRIPTION
The unversioned postgresql-client package installed pg_dump 17 while the
Railway PostgreSQL server upgraded to 18, causing all backups to fail.

- Dockerfile: add PGDG apt repo and pin postgresql-client-18
- nixpacks.toml: same pin for Nixpacks builds
- _find_pg_tool: check versioned Debian paths before shutil.which so a
  higher-version versioned installation always wins over whatever lands on PATH
- Tests: update to cover the new preference order

https://claude.ai/code/session_01EexSMw7pXPoBQ7Zu4TEwbe