### PR TITLE
Fix backup file size always showing unknown for S3 storage

### DIFF
--- a/apps/backups/services/backup_service.py
+++ b/apps/backups/services/backup_service.py
@@ -139,10 +139,9 @@ def run_database_backup(record_id: str) -> None:
                 "Verify B2 credentials and that the bucket exists."
             )
 
-        # Best-effort size — only works for filesystem; S3 skips silently.
         file_size: int | None = None
         try:
-            file_size = storage.size(filename)
+            file_size = underlying.size(filename)
         except Exception:
             pass
 

--- a/apps/backups/tests/test_backup_service.py
+++ b/apps/backups/tests/test_backup_service.py
@@ -20,6 +20,9 @@ def _make_mock_storage(before, after, size=1024):
         def delete(self, name):
             pass
 
+        def size(self, name):
+            return size
+
     mock_storage = MagicMock()
     mock_storage.storage = FakeS3Storage()
     mock_storage.list_backups.side_effect = [list(before), list(after)]


### PR DESCRIPTION
storage.size() on dbbackup's wrapper silently fails for S3; use the unwrapped underlying storage object (already used for exists() checks).

https://claude.ai/code/session_01EexSMw7pXPoBQ7Zu4TEwbe