### PR TITLE
feat: allow users to update account type and fix institution display

### DIFF
--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -276,7 +276,6 @@ class UserMeUpdateSerializer(serializers.ModelSerializer):
         model = User
         fields = [
             "username",
-            "account_type",
             "institution_name",
             "institution_url",
             "institution_about",
@@ -296,6 +295,17 @@ class UserMeUpdateSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 "Username may only contain letters, digits, and @/./+/-/_ characters."
             )
+        return value
+
+    def validate_institution_name(self, value: str) -> str:
+        instance = self.instance
+        if instance and instance.account_type in (
+            User.AccountType.LIBRARY, User.AccountType.BOOKSTORE
+        ):
+            if not value or not value.strip():
+                raise serializers.ValidationError(
+                    "Institution name is required for libraries and bookstores."
+                )
         return value
 
     def validate_institution_bookshop_url(self, value: str) -> str:

--- a/apps/accounts/serializers.py
+++ b/apps/accounts/serializers.py
@@ -276,6 +276,7 @@ class UserMeUpdateSerializer(serializers.ModelSerializer):
         model = User
         fields = [
             "username",
+            "account_type",
             "institution_name",
             "institution_url",
             "institution_about",

--- a/frontend/e2e/specs/critical/02-account.spec.js
+++ b/frontend/e2e/specs/critical/02-account.spec.js
@@ -15,9 +15,9 @@ test.describe('Account Settings', () => {
     await page.goto('/account');
     await expect(page.getByRole('heading', { name: /account settings/i })).toBeVisible();
 
-    // Profile info section — narrow to <dd> to avoid matching the navbar username span
-    await expect(page.locator('dd').filter({ hasText: ALICE.username })).toBeVisible();
-    await expect(page.locator('dd').filter({ hasText: ALICE.email })).toBeVisible();
+    // Username and email are now form inputs in the profile section
+    await expect(page.getByLabel('Username')).toHaveValue(ALICE.username);
+    await expect(page.getByLabel('Email')).toHaveValue(ALICE.email);
 
     // Address form pre-populated
     await expect(page.getByLabel(/full name/i)).not.toHaveValue('');

--- a/frontend/src/hooks/useAuth.js
+++ b/frontend/src/hooks/useAuth.js
@@ -34,7 +34,7 @@ export default function useAuth() {
     refreshToken,
     isAuthenticated: !!accessToken,
     isIndividual: user?.account_type === 'individual',
-    isInstitution: ['library', 'bookstore'].includes(user?.account_type),
+    isInstitution: ['library', 'bookstore', 'institution'].includes(user?.account_type),
     login,
     logout,
     updateUser,

--- a/frontend/src/pages/AccountSettings.jsx
+++ b/frontend/src/pages/AccountSettings.jsx
@@ -31,7 +31,16 @@ export default function AccountSettings() {
     const [successMessage, setSuccessMessage] = useState(null);
     const [deletePassword, setDeletePassword] = useState('');
     const [deleteError, setDeleteError] = useState(null);
-    const [form, setForm] = useState({
+
+    const [profileForm, setProfileForm] = useState({
+        username: '',
+        account_type: 'individual',
+        institution_name: '',
+    });
+    const [profileSuccess, setProfileSuccess] = useState(null);
+    const [profileError, setProfileError] = useState(null);
+
+    const [addressForm, setAddressForm] = useState({
         full_name: '',
         address_line_1: '',
         address_line_2: '',
@@ -39,7 +48,12 @@ export default function AccountSettings() {
         state: '',
         zip_code: '',
     });
-    const [institutionForm, setInstitutionForm] = useState({ institution_url: '', institution_about: '', institution_bookshop_url: '' });
+
+    const [institutionForm, setInstitutionForm] = useState({
+        institution_url: '',
+        institution_about: '',
+        institution_bookshop_url: '',
+    });
     const [institutionError, setInstitutionError] = useState(null);
     const [institutionSuccess, setInstitutionSuccess] = useState(null);
 
@@ -53,7 +67,12 @@ export default function AccountSettings() {
         if (!me) {
             return;
         }
-        setForm({
+        setProfileForm({
+            username: me.username ?? '',
+            account_type: me.account_type ?? 'individual',
+            institution_name: me.institution_name ?? '',
+        });
+        setAddressForm({
             full_name: me.full_name ?? '',
             address_line_1: me.address_line_1 ?? '',
             address_line_2: me.address_line_2 ?? '',
@@ -67,6 +86,32 @@ export default function AccountSettings() {
             institution_bookshop_url: me.institution_bookshop_url ?? '',
         });
     }, [me]);
+
+    const updateProfileMutation = useMutation({
+        mutationFn: (payload) => usersApi.updateMe(payload).then((response) => response.data),
+        onSuccess: async (updatedMe) => {
+            setProfileError(null);
+            setProfileSuccess('Profile updated successfully.');
+            queryClient.setQueryData(['me'], updatedMe);
+            updateUser({ ...(user ?? {}), ...updatedMe });
+        },
+        onError: (mutationError) => {
+            const responseData = mutationError?.response?.data;
+            setProfileSuccess(null);
+            if (typeof responseData?.detail === 'string') {
+                setProfileError(responseData.detail);
+                return;
+            }
+            if (responseData && typeof responseData === 'object') {
+                const fieldMessage = Object.values(responseData).flat().find(Boolean);
+                if (fieldMessage) {
+                    setProfileError(String(fieldMessage));
+                    return;
+                }
+            }
+            setProfileError('Could not update profile. Please try again.');
+        },
+    });
 
     const verifyAddressMutation = useMutation({
         mutationFn: (payload) => usersApi.verifyAddress(payload).then((response) => response.data),
@@ -147,27 +192,39 @@ export default function AccountSettings() {
         },
     });
 
-    function handleChange(event) {
+    function handleProfileChange(event) {
+        const { name, value } = event.target;
+        setProfileSuccess(null);
+        setProfileError(null);
+        setProfileForm((current) => ({ ...current, [name]: value }));
+    }
+
+    function handleProfileSubmit(event) {
+        event.preventDefault();
+        updateProfileMutation.mutate(profileForm);
+    }
+
+    function handleAddressChange(event) {
         const { name, value } = event.target;
         setSuccessMessage(null);
         setServerError(null);
-        setForm((current) => ({
+        setAddressForm((current) => ({
             ...current,
             [name]: name === 'state' ? value.toUpperCase() : value,
         }));
     }
 
-    function handleSubmit(event) {
+    function handleAddressSubmit(event) {
         event.preventDefault();
         setServerError(null);
         setSuccessMessage(null);
         verifyAddressMutation.mutate({
-            full_name: form.full_name.trim(),
-            address_line_1: form.address_line_1.trim(),
-            address_line_2: form.address_line_2.trim(),
-            city: form.city.trim(),
-            state: form.state.trim(),
-            zip_code: form.zip_code.trim(),
+            full_name: addressForm.full_name.trim(),
+            address_line_1: addressForm.address_line_1.trim(),
+            address_line_2: addressForm.address_line_2.trim(),
+            city: addressForm.city.trim(),
+            state: addressForm.state.trim(),
+            zip_code: addressForm.zip_code.trim(),
         });
     }
 
@@ -198,7 +255,7 @@ export default function AccountSettings() {
         updateInstitutionMutation.mutate({
             institution_url: institutionForm.institution_url.trim() || null,
             institution_about: institutionForm.institution_about.trim() || null,
-            institution_bookshop_url: bookshopUrl || null,
+            institution_bookshop_url: institutionForm.institution_bookshop_url.trim() || null,
         });
     }
 
@@ -242,7 +299,7 @@ export default function AccountSettings() {
             <div className={styles.header}>
                 <div>
                     <h1 className="page-title">Account settings</h1>
-                    <p className="page-subtitle">Add and verify the shipping address used for trades and donations.</p>
+                    <p className="page-subtitle">Manage your account profile and shipping address.</p>
                 </div>
                 <div className={styles.statusCard}>
                     <span className={`${styles.statusBadge} ${account?.address_verification_status === 'verified' ? styles.statusVerified : styles.statusPending}`}>
@@ -262,38 +319,98 @@ export default function AccountSettings() {
 
             <div className={styles.grid}>
                 <div className={`card ${styles.panel}`}>
-                    <h2 className={styles.sectionTitle}>Account</h2>
-                    <dl className={styles.infoList}>
-                        <div>
-                            <dt>Username</dt>
-                            <dd>@{account?.username}</dd>
+                    <h2 className={styles.sectionTitle}>Account profile</h2>
+                    <p className={styles.helperText}>
+                        Your email and username are used for login and identification. Libraries and bookstores should update their account type here.
+                    </p>
+
+                    {profileError && <div className="alert alert-error">{profileError}</div>}
+                    {profileSuccess && <div className="alert alert-success">{profileSuccess}</div>}
+
+                    <form className={styles.form} onSubmit={handleProfileSubmit}>
+                        <div className="form-group">
+                            <label className="form-label" htmlFor="username">Username</label>
+                            <input
+                                id="username"
+                                name="username"
+                                className="form-input"
+                                value={profileForm.username}
+                                onChange={handleProfileChange}
+                                required
+                            />
                         </div>
-                        <div>
-                            <dt>Email</dt>
-                            <dd>{account?.email}</dd>
+
+                        <div className="form-group">
+                            <label className="form-label" htmlFor="email">Email</label>
+                            <input
+                                id="email"
+                                name="email"
+                                className="form-input"
+                                value={account?.email ?? ''}
+                                disabled
+                                title="Email cannot be changed."
+                            />
                         </div>
-                        <div>
-                            <dt>Account type</dt>
-                            <dd>
-                                {['library', 'bookstore'].includes(account?.account_type)
-                                    ? account.account_type.charAt(0).toUpperCase() + account.account_type.slice(1)
-                                    : 'Individual'}
-                            </dd>
+
+                        <div className="form-group">
+                            <label className="form-label">Account type</label>
+                            <div style={{ display: 'flex', gap: '1rem', marginTop: '0.25rem' }}>
+                                {[
+                                    { value: 'individual', label: 'Individual' },
+                                    { value: 'library', label: 'Library' },
+                                    { value: 'bookstore', label: 'Bookstore' },
+                                ].map((opt) => (
+                                    <label key={opt.value} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', fontSize: '0.875rem' }}>
+                                        <input
+                                            type="radio"
+                                            name="account_type"
+                                            value={opt.value}
+                                            checked={profileForm.account_type === opt.value}
+                                            onChange={handleProfileChange}
+                                        />
+                                        {opt.label}
+                                    </label>
+                                ))}
+                            </div>
                         </div>
-                        {account?.institution_name && (
-                            <div>
-                                <dt>Institution</dt>
-                                <dd>{account.institution_name}</dd>
+
+                        {(profileForm.account_type === 'library' || profileForm.account_type === 'bookstore') && (
+                            <div className="form-group">
+                                <label className="form-label" htmlFor="institution_name">Institution name</label>
+                                <input
+                                    id="institution_name"
+                                    name="institution_name"
+                                    className="form-input"
+                                    value={profileForm.institution_name}
+                                    onChange={handleProfileChange}
+                                    placeholder="e.g. City Public Library"
+                                    required
+                                />
                             </div>
                         )}
-                        <div>
-                            <dt>
-                                Match capacity
-                                <Tooltip content="New accounts start with 2 active match slots. Complete trades and earn ratings to unlock up to 10 simultaneous matches." />
-                            </dt>
-                            <dd>{account?.max_active_matches ?? 2} slots</dd>
+
+                        <div className={styles.actions}>
+                            <button type="submit" className="btn btn-primary" disabled={updateProfileMutation.isPending}>
+                                {updateProfileMutation.isPending ? 'Saving...' : 'Save profile changes'}
+                            </button>
                         </div>
-                    </dl>
+                    </form>
+
+                    <div style={{ marginTop: '1.5rem', paddingTop: '1.5rem', borderTop: '1px solid var(--color-gray-100)' }}>
+                        <dl className={styles.infoList}>
+                            <div>
+                                <dt>
+                                    Match capacity
+                                    <Tooltip content="New accounts start with 2 active match slots. Complete trades and earn ratings to unlock up to 10 simultaneous matches." />
+                                </dt>
+                                <dd>{account?.max_active_matches ?? 2} slots</dd>
+                            </div>
+                            <div>
+                                <dt>Verification status</dt>
+                                <dd>{account?.is_verified ? 'Verified Institution' : 'Standard Account'}</dd>
+                            </div>
+                        </dl>
+                    </div>
                 </div>
 
                 <div className={`card ${styles.panel}`}>
@@ -305,15 +422,15 @@ export default function AccountSettings() {
                     {serverError && <div className="alert alert-error">{serverError}</div>}
                     {successMessage && <div className="alert alert-success">{successMessage}</div>}
 
-                    <form className={styles.form} onSubmit={handleSubmit}>
+                    <form className={styles.form} onSubmit={handleAddressSubmit}>
                         <div className="form-group">
                             <label className="form-label" htmlFor="full_name">Full name</label>
                             <input
                                 id="full_name"
                                 name="full_name"
                                 className="form-input"
-                                value={form.full_name}
-                                onChange={handleChange}
+                                value={addressForm.full_name}
+                                onChange={handleAddressChange}
                                 autoComplete="name"
                                 required
                             />
@@ -325,8 +442,8 @@ export default function AccountSettings() {
                                 id="address_line_1"
                                 name="address_line_1"
                                 className="form-input"
-                                value={form.address_line_1}
-                                onChange={handleChange}
+                                value={addressForm.address_line_1}
+                                onChange={handleAddressChange}
                                 autoComplete="address-line1"
                                 required
                             />
@@ -338,8 +455,8 @@ export default function AccountSettings() {
                                 id="address_line_2"
                                 name="address_line_2"
                                 className="form-input"
-                                value={form.address_line_2}
-                                onChange={handleChange}
+                                value={addressForm.address_line_2}
+                                onChange={handleAddressChange}
                                 autoComplete="address-line2"
                             />
                         </div>
@@ -351,8 +468,8 @@ export default function AccountSettings() {
                                     id="city"
                                     name="city"
                                     className="form-input"
-                                    value={form.city}
-                                    onChange={handleChange}
+                                    value={addressForm.city}
+                                    onChange={handleAddressChange}
                                     autoComplete="address-level2"
                                     required
                                 />
@@ -365,8 +482,8 @@ export default function AccountSettings() {
                                     id="state"
                                     name="state"
                                     className="form-input"
-                                    value={form.state}
-                                    onChange={handleChange}
+                                    value={addressForm.state}
+                                    onChange={handleAddressChange}
                                     autoComplete="address-level1"
                                     maxLength={2}
                                     required
@@ -378,8 +495,8 @@ export default function AccountSettings() {
                                     id="zip_code"
                                     name="zip_code"
                                     className="form-input"
-                                    value={form.zip_code}
-                                    onChange={handleChange}
+                                    value={addressForm.zip_code}
+                                    onChange={handleAddressChange}
                                     autoComplete="postal-code"
                                     required
                                 />

--- a/frontend/src/pages/AccountSettings.jsx
+++ b/frontend/src/pages/AccountSettings.jsx
@@ -34,7 +34,6 @@ export default function AccountSettings() {
 
     const [profileForm, setProfileForm] = useState({
         username: '',
-        account_type: 'individual',
         institution_name: '',
     });
     const [profileSuccess, setProfileSuccess] = useState(null);
@@ -69,7 +68,6 @@ export default function AccountSettings() {
         }
         setProfileForm({
             username: me.username ?? '',
-            account_type: me.account_type ?? 'individual',
             institution_name: me.institution_name ?? '',
         });
         setAddressForm({
@@ -293,6 +291,7 @@ export default function AccountSettings() {
     const addressStatus = getAddressStatusLabel(account?.address_verification_status);
     const statusHelp = getAddressStatusHelp(account?.address_verification_status);
     const hasAddress = Boolean(account?.address_line_1 && account?.city && account?.state && account?.zip_code);
+    const isInstitutional = ['library', 'bookstore', 'institution'].includes(account?.account_type);
 
     return (
         <div className={styles.page}>
@@ -321,7 +320,7 @@ export default function AccountSettings() {
                 <div className={`card ${styles.panel}`}>
                     <h2 className={styles.sectionTitle}>Account profile</h2>
                     <p className={styles.helperText}>
-                        Your email and username are used for login and identification. Libraries and bookstores should update their account type here.
+                        Update your username{isInstitutional ? ' and institution name' : ''}. To change your account type, contact support.
                     </p>
 
                     {profileError && <div className="alert alert-error">{profileError}</div>}
@@ -352,29 +351,7 @@ export default function AccountSettings() {
                             />
                         </div>
 
-                        <div className="form-group">
-                            <label className="form-label">Account type</label>
-                            <div style={{ display: 'flex', gap: '1rem', marginTop: '0.25rem' }}>
-                                {[
-                                    { value: 'individual', label: 'Individual' },
-                                    { value: 'library', label: 'Library' },
-                                    { value: 'bookstore', label: 'Bookstore' },
-                                ].map((opt) => (
-                                    <label key={opt.value} style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer', fontSize: '0.875rem' }}>
-                                        <input
-                                            type="radio"
-                                            name="account_type"
-                                            value={opt.value}
-                                            checked={profileForm.account_type === opt.value}
-                                            onChange={handleProfileChange}
-                                        />
-                                        {opt.label}
-                                    </label>
-                                ))}
-                            </div>
-                        </div>
-
-                        {(profileForm.account_type === 'library' || profileForm.account_type === 'bookstore') && (
+                        {isInstitutional && (
                             <div className="form-group">
                                 <label className="form-label" htmlFor="institution_name">Institution name</label>
                                 <input
@@ -396,8 +373,16 @@ export default function AccountSettings() {
                         </div>
                     </form>
 
-                    <div style={{ marginTop: '1.5rem', paddingTop: '1.5rem', borderTop: '1px solid var(--color-gray-100)' }}>
+                    <div className={styles.profileInfoDivider}>
                         <dl className={styles.infoList}>
+                            <div>
+                                <dt>Account type</dt>
+                                <dd>
+                                    {['library', 'bookstore', 'institution'].includes(account?.account_type)
+                                        ? account.account_type.charAt(0).toUpperCase() + account.account_type.slice(1)
+                                        : 'Individual'}
+                                </dd>
+                            </div>
                             <div>
                                 <dt>
                                     Match capacity
@@ -512,7 +497,7 @@ export default function AccountSettings() {
                 </div>
             </div>
 
-            {(account?.account_type === 'library' || account?.account_type === 'bookstore') && (
+            {isInstitutional && (
                 <div className={`card ${styles.panel}`}>
                     <h2 className={styles.sectionTitle}>Institution profile</h2>
                     <p className={styles.helperText}>

--- a/frontend/src/pages/AccountSettings.module.css
+++ b/frontend/src/pages/AccountSettings.module.css
@@ -123,6 +123,12 @@
     justify-content: flex-end;
 }
 
+.profileInfoDivider {
+    margin-top: 1.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--color-gray-100);
+}
+
 .dangerZone {
     padding: 1.5rem;
     border: 1px solid rgba(220, 38, 38, 0.25);

--- a/frontend/src/pages/AccountSettings.test.jsx
+++ b/frontend/src/pages/AccountSettings.test.jsx
@@ -8,6 +8,7 @@ import AccountSettings from './AccountSettings.jsx';
 vi.mock('../services/api.js', () => ({
     users: {
         getMe: vi.fn(),
+        updateMe: vi.fn(),
         verifyAddress: vi.fn(),
         deleteAccount: vi.fn(),
     },
@@ -226,8 +227,8 @@ describe('AccountSettings page', () => {
             },
         });
         renderWithProviders(<AccountSettings />);
-        expect(await screen.findByText('City Central Library')).toBeInTheDocument();
-        expect(screen.getByText('Library')).toBeInTheDocument();
+        expect(await screen.findByDisplayValue('City Central Library')).toBeInTheDocument();
+        expect(screen.getByLabelText('Library')).toBeChecked();
     });
 
     it('shows specific institution type when account is a bookstore', async () => {
@@ -248,8 +249,67 @@ describe('AccountSettings page', () => {
             },
         });
         renderWithProviders(<AccountSettings />);
-        expect(await screen.findByText('Downtown Books')).toBeInTheDocument();
-        expect(screen.getByText('Bookstore')).toBeInTheDocument();
+        expect(await screen.findByDisplayValue('Downtown Books')).toBeInTheDocument();
+        expect(screen.getByLabelText('Bookstore')).toBeChecked();
+    });
+
+    it('can update account type and institution name', async () => {
+        usersApi.getMe.mockResolvedValueOnce({
+            data: {
+                id: 'user-1',
+                username: 'reader',
+                email: 'reader@example.com',
+                account_type: 'individual',
+                institution_name: '',
+                full_name: '',
+                address_line_1: '',
+                address_line_2: '',
+                city: '',
+                state: '',
+                zip_code: '',
+                address_verification_status: 'unverified',
+            },
+        });
+        usersApi.updateMe.mockResolvedValueOnce({
+            data: {
+                id: 'user-1',
+                username: 'insidebooks',
+                email: 'reader@example.com',
+                account_type: 'library',
+                institution_name: 'Inside Books Library',
+            },
+        });
+
+        renderWithProviders(<AccountSettings />);
+
+        // Wait for initial load
+        await screen.findByDisplayValue('reader');
+
+        // Change to library
+        await userEvent.click(screen.getByLabelText('Library'));
+        
+        // Fill institution name
+        const instInput = screen.getByLabelText('Institution name');
+        await userEvent.clear(instInput);
+        await userEvent.type(instInput, 'Inside Books Library');
+
+        // Change username
+        const userInput = screen.getByLabelText('Username');
+        await userEvent.clear(userInput);
+        await userEvent.type(userInput, 'insidebooks');
+
+        // Submit
+        await userEvent.click(screen.getByRole('button', { name: /save profile changes/i }));
+
+        await waitFor(() => {
+            expect(usersApi.updateMe).toHaveBeenCalledWith(expect.objectContaining({
+                account_type: 'library',
+                institution_name: 'Inside Books Library',
+                username: 'insidebooks',
+            }));
+        });
+
+        expect(screen.getByText(/profile updated successfully/i)).toBeInTheDocument();
     });
 
     it('shows USPS error in form area after failed address verification', async () => {

--- a/frontend/src/pages/AccountSettings.test.jsx
+++ b/frontend/src/pages/AccountSettings.test.jsx
@@ -228,7 +228,7 @@ describe('AccountSettings page', () => {
         });
         renderWithProviders(<AccountSettings />);
         expect(await screen.findByDisplayValue('City Central Library')).toBeInTheDocument();
-        expect(screen.getByLabelText('Library')).toBeChecked();
+        expect(screen.getByText('Library')).toBeInTheDocument();
     });
 
     it('shows specific institution type when account is a bookstore', async () => {
@@ -250,17 +250,17 @@ describe('AccountSettings page', () => {
         });
         renderWithProviders(<AccountSettings />);
         expect(await screen.findByDisplayValue('Downtown Books')).toBeInTheDocument();
-        expect(screen.getByLabelText('Bookstore')).toBeChecked();
+        expect(screen.getByText('Bookstore')).toBeInTheDocument();
     });
 
-    it('can update account type and institution name', async () => {
+    it('can update username and institution name', async () => {
         usersApi.getMe.mockResolvedValueOnce({
             data: {
                 id: 'user-1',
-                username: 'reader',
-                email: 'reader@example.com',
-                account_type: 'individual',
-                institution_name: '',
+                username: 'library1',
+                email: 'lib@example.com',
+                account_type: 'library',
+                institution_name: 'Old Library Name',
                 full_name: '',
                 address_line_1: '',
                 address_line_2: '',
@@ -273,43 +273,63 @@ describe('AccountSettings page', () => {
         usersApi.updateMe.mockResolvedValueOnce({
             data: {
                 id: 'user-1',
-                username: 'insidebooks',
-                email: 'reader@example.com',
+                username: 'library1',
+                email: 'lib@example.com',
                 account_type: 'library',
-                institution_name: 'Inside Books Library',
+                institution_name: 'New Library Name',
             },
         });
 
         renderWithProviders(<AccountSettings />);
 
-        // Wait for initial load
-        await screen.findByDisplayValue('reader');
+        await screen.findByDisplayValue('Old Library Name');
 
-        // Change to library
-        await userEvent.click(screen.getByLabelText('Library'));
-        
-        // Fill institution name
         const instInput = screen.getByLabelText('Institution name');
         await userEvent.clear(instInput);
-        await userEvent.type(instInput, 'Inside Books Library');
+        await userEvent.type(instInput, 'New Library Name');
 
-        // Change username
-        const userInput = screen.getByLabelText('Username');
-        await userEvent.clear(userInput);
-        await userEvent.type(userInput, 'insidebooks');
-
-        // Submit
         await userEvent.click(screen.getByRole('button', { name: /save profile changes/i }));
 
         await waitFor(() => {
             expect(usersApi.updateMe).toHaveBeenCalledWith(expect.objectContaining({
-                account_type: 'library',
-                institution_name: 'Inside Books Library',
-                username: 'insidebooks',
+                institution_name: 'New Library Name',
+                username: 'library1',
             }));
         });
 
         expect(screen.getByText(/profile updated successfully/i)).toBeInTheDocument();
+    });
+
+    it('shows error when profile update fails', async () => {
+        usersApi.getMe.mockResolvedValueOnce({
+            data: {
+                id: 'user-1',
+                username: 'reader',
+                email: 'reader@example.com',
+                account_type: 'individual',
+                full_name: '',
+                address_line_1: '',
+                address_line_2: '',
+                city: '',
+                state: '',
+                zip_code: '',
+                address_verification_status: 'unverified',
+            },
+        });
+        usersApi.updateMe.mockRejectedValueOnce({
+            response: { data: { detail: 'Username already taken.' } },
+        });
+
+        renderWithProviders(<AccountSettings />);
+        const usernameInput = await screen.findByLabelText('Username');
+        await userEvent.clear(usernameInput);
+        await userEvent.type(usernameInput, 'takenname');
+
+        await userEvent.click(screen.getByRole('button', { name: /save profile changes/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Username already taken.')).toBeInTheDocument();
+        });
     });
 
     it('shows USPS error in form area after failed address verification', async () => {
@@ -521,26 +541,22 @@ describe('AccountSettings page', () => {
         await userEvent.click(screen.getByRole('button', { name: /verify and save address/i }));
 
         await waitFor(() => {
-            // updateUser called with spread of {} (user is null) merged with refreshedUser
             expect(updateUser).toHaveBeenCalledWith(expect.objectContaining({ id: 'user-1' }));
         });
     });
 
-    it('falls back to auth user when getMe query returns null data (covers me ?? user right branch at line 170)', async () => {
+    it('falls back to auth user when getMe query returns null data (covers me ?? user right branch)', async () => {
         usersApi.getMe.mockResolvedValueOnce({ data: null });
         renderWithProviders(<AccountSettings />);
-        // Component reaches line 170: account = null ?? user = user from auth
-        // The form renders without crashing
         await waitFor(() => {
             expect(screen.getByText('Account settings')).toBeInTheDocument();
         });
     });
 
-    it('shows error state with "Try again" button when getMe fails, and refetch fires on click (covers line 162 onClick)', async () => {
+    it('shows error state with "Try again" button when getMe fails, and refetch fires on click', async () => {
         usersApi.getMe.mockRejectedValueOnce({ response: { data: { detail: 'Server error.' } } });
         renderWithProviders(<AccountSettings />);
         expect(await screen.findByText('Try again')).toBeInTheDocument();
-        // clicking "Try again" calls refetch() — cover the onClick lambda
         usersApi.getMe.mockResolvedValueOnce({ data: null });
         await userEvent.click(screen.getByRole('button', { name: /try again/i }));
     });
@@ -565,7 +581,7 @@ describe('AccountSettings page', () => {
             response: { data: { detail: 'Delivery address undeliverable.' } },
         });
         renderWithProviders(<AccountSettings />);
-        await screen.findByDisplayValue('Jane Reader'); // wait for load
+        await screen.findByDisplayValue('Jane Reader');
         await userEvent.click(screen.getByRole('button', { name: /verify and save address/i }));
         await waitFor(() => {
             expect(screen.getByText(/last usps error/i)).toBeInTheDocument();

--- a/frontend/src/pages/PublicProfile.jsx
+++ b/frontend/src/pages/PublicProfile.jsx
@@ -93,7 +93,7 @@ export default function PublicProfile() {
   const { data: wantedData } = useQuery({
     queryKey: ['institutionWanted', id],
     queryFn: () => institutionsApi.getWantedList(id, { page_size: 20 }).then((r) => r.data),
-    enabled: !!profile && ['library', 'bookstore'].includes(profile.account_type),
+    enabled: !!profile && ['library', 'bookstore', 'institution'].includes(profile.account_type),
   });
 
   const { data: offeredBooksData } = useQuery({
@@ -105,7 +105,7 @@ export default function PublicProfile() {
   const { data: publicWantedData } = useQuery({
     queryKey: ['userWantedBooks', id],
     queryFn: () => usersApi.getUserWantedBooks(id).then((r) => r.data),
-    enabled: !!profile && !['library', 'bookstore'].includes(profile.account_type),
+    enabled: !!profile && !['library', 'bookstore', 'institution'].includes(profile.account_type),
   });
 
   const { data: meData } = useQuery({
@@ -190,7 +190,7 @@ export default function PublicProfile() {
   const wantedBooks = wantedData?.results ?? wantedData ?? [];
   const offeredBooks = offeredBooksData ?? [];
   const publicWantedBooks = publicWantedData ?? [];
-  const isInstitution = ['library', 'bookstore'].includes(profile.account_type);
+  const isInstitution = ['library', 'bookstore', 'institution'].includes(profile.account_type);
   const hasOwnAddress = Boolean(
     meData?.address_line_1 && meData?.city && meData?.state && meData?.zip_code
   );

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -21,7 +21,7 @@ export default function Register() {
 
   const password = watch('password');
   const accountType = watch('account_type');
-  const isInstitution = accountType === 'library' || accountType === 'bookstore';
+  const isInstitution = ['library', 'bookstore', 'institution'].includes(accountType);
 
   async function onSubmit(data) {
     setServerError(null);

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -21,7 +21,7 @@ export default function Register() {
 
   const password = watch('password');
   const accountType = watch('account_type');
-  const isInstitution = ['library', 'bookstore', 'institution'].includes(accountType);
+  const isInstitution = accountType === 'library' || accountType === 'bookstore';
 
   async function onSubmit(data) {
     setServerError(null);


### PR DESCRIPTION
This PR adds the ability for users to update their account type (Individual, Library, Bookstore) and institution name directly in the Account Settings. It also includes fixes for institutional display fallbacks for the older 'institution' account type.