### PR TITLE
Update dashboard e2e test to match new home page heading

### DIFF
--- a/frontend/e2e/specs/critical/10-dashboard.spec.js
+++ b/frontend/e2e/specs/critical/10-dashboard.spec.js
@@ -214,6 +214,6 @@ test.describe('Dashboard', () => {
     await page.getByRole('link', { name: /browse books/i }).click();
     // Home page URL is just /
     await expect(page).toHaveURL(/localhost:\d+\/?$/, { timeout: 8_000 });
-    await expect(page.getByRole('heading', { name: /trade books/i })).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByRole('heading', { name: /you could be the reason/i })).toBeVisible({ timeout: 8_000 });
   });
 });


### PR DESCRIPTION
## Summary
Updates the critical dashboard e2e test to verify the correct heading text on the home page after a recent UI change.

## Changes
- Updated the expected heading text in the "Browse Books" navigation test from `/trade books/i` to `/you could be the reason/i` to match the current home page heading

## Details
The test was checking for a heading with the text "Trade Books" when navigating to the home page via the "Browse Books" link. This assertion has been updated to expect "You Could Be The Reason" instead, which reflects the actual heading currently displayed on the home page.

https://claude.ai/code/session_01UcJmm5Z7JcNRAmT1KFUQxS